### PR TITLE
Small fixes and improvements

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 120
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,241 @@
+# Created by https://www.toptal.com/developers/gitignore/api/c++,jupyternotebooks,python,vim
+# Edit at https://www.toptal.com/developers/gitignore?templates=c++,jupyternotebooks,python,vim
+
+### C++ ###
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+### JupyterNotebooks ###
+# gitignore template for Jupyter Notebooks
+# website: http://jupyter.org/
+
+.ipynb_checkpoints
+*/.ipynb_checkpoints/*
+
+# IPython
+profile_default/
+ipython_config.py
+
+# Remove previous ipynb_checkpoints
+#   git rm -r .ipynb_checkpoints/
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+
+# IPython
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.toptal.com/developers/gitignore/api/c++,jupyternotebooks,python,vim

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 project(NBP_jupyter)
 
 set(CMAKE_CXX_STANDARD 14)
-FIND_PACKAGE( OpenMP)
+FIND_PACKAGE(OpenMP)
 if(OPENMP_FOUND)
     message("OPENMP FOUND")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
@@ -15,3 +15,9 @@ add_executable(NBP_jupyter
         simulateFER.cpp
         stabilizerCodes.cpp
         stabilizerCodes.h)
+
+if(MSVC)
+    target_compile_options(NBP_jupyter PRIVATE /W4 /WX)
+else()
+    target_compile_options(NBP_jupyter PRIVATE -Wall -Wextra -Wpedantic)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,4 +14,4 @@ include_directories(.)
 add_executable(NBP_jupyter
         simulateFER.cpp
         stabilizerCodes.cpp
-        stabilizierCodes.h)
+        stabilizerCodes.h)

--- a/NBP_demo.ipynb
+++ b/NBP_demo.ipynb
@@ -22,7 +22,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This work has received funding from the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation programme (grant agreement No. 101001899)."
+    "This work has received funding from the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation programme (grant agreement No. 101001899).\n",
+    "\n",
+    "The code in this file: Copyright 2023 Sisi Miao, Communications Engineering Lab @ KIT.\n",
+    "\n",
+    "This source code is supplied under [MIT License](https://github.com/kit-cel/Quantum-Neural-BP4-demo/blob/master/LICENSE.md)."
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -2,12 +2,23 @@
 ## Sisi Miao, Alexander Schnerring, Haizheng Li, and Laurent Schmalen
 
 This jupyter notebook provides the implementation which produces the results in [1]. In specific, this notebook contains:
-* The neural BP(NBP) decoder
+* The neural BP (NBP) decoder
 * The function for training, can be run on CPU or GPU
 * Call on the C++ functions which evaluate the trained decoder
-* Addtionally, the overcomplete check matrices used in [1] are provided in the ./PCM folder
+* Additionally, the overcomplete check matrices used in [1] are provided in the ./PCM folder
 
 [1] S. Miao, A. Schnerring, H. Li and L. Schmalen, "Neural belief propagation decoding of quantum LDPC codes using overcomplete check matrices," Proc. IEEE Inform. Theory Workshop (ITW), Saint-Malo, France, Apr. 2023, https://arxiv.org/abs/2212.10245
 
-## abstract:
-The recent success in constructing asymptotically good quantum low-density parity-check (QLDPC) codes makes this family of codes a promising candidate for error-correcting schemes in quantum computing. However, conventional belief propagation (BP) decoding of QLDPC codes does not yield satisfying performance due to the presence of unavoidable short cycles in their Tanner graph and the special degeneracy phenomenon. In this work, we propose to decode QLDPC codes based on a check matrix with redundant rows, generated from linear combinations of the rows in the original check matrix. This approach yields a significant improvement in decoding performance with the additional advantage of very low decoding latency. Furthermore, we propose a novel neural belief propagation decoder based on the quaternary BP decoder of QLDPC codes which leads to further decoding performance improvements.
+## Abstract
+The recent success in constructing asymptotically good quantum low-density
+parity-check (QLDPC) codes makes this family of codes a promising candidate for
+error-correcting schemes in quantum computing. However, conventional belief
+propagation (BP) decoding of QLDPC codes does not yield satisfying performance
+due to the presence of unavoidable short cycles in their Tanner graph and the
+special degeneracy phenomenon. In this work, we propose to decode QLDPC codes
+based on a check matrix with redundant rows, generated from linear combinations
+of the rows in the original check matrix. This approach yields a significant
+improvement in decoding performance with the additional advantage of very low
+decoding latency. Furthermore, we propose a novel neural belief propagation
+decoder based on the quaternary BP decoder of QLDPC codes which leads to
+further decoding performance improvements.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This jupyter notebook provides the implementation which produces the results in 
 * The neural BP (NBP) decoder
 * The function for training, can be run on CPU or GPU
 * Call on the C++ functions which evaluate the trained decoder
-* Additionally, the overcomplete check matrices used in [1] are provided in the ./PCM folder
+* Additionally, the overcomplete check matrices used in [1] are provided in the ./PCMs folder
 
 [1] S. Miao, A. Schnerring, H. Li and L. Schmalen, "Neural belief propagation decoding of quantum LDPC codes using overcomplete check matrices," Proc. IEEE Inform. Theory Workshop (ITW), Saint-Malo, France, Apr. 2023, https://arxiv.org/abs/2212.10245
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+torch
+notebook
+numpy
+tqdm
+matplotlib

--- a/simulateFER.cpp
+++ b/simulateFER.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2023 Sisi Miao, Communications Engineering Lab @ KIT
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This file accompanies the paper
+ *     S. Miao, A. Schnerring, H. Li and L. Schmalen,
+ *     "Neural belief propagation decoding of quantum LDPC codes using overcomplete check matrices,"
+ *     Proc. IEEE Inform. Theory Workshop (ITW), Saint-Malo, France, Apr. 2023, https://arxiv.org/abs/2212.10245
+ */
 #include "stabilizerCodes.h"
 #include <iostream>
 #include <omp.h>

--- a/simulateFER.cpp
+++ b/simulateFER.cpp
@@ -1,50 +1,56 @@
-#include <iostream>
 #include "stabilizerCodes.h"
-#include<omp.h>
 #include <iomanip>
+#include <iostream>
+#include <omp.h>
 int main() {
-    unsigned n=46;
-    unsigned k=2;
-    unsigned m=800;
+    unsigned n = 46;
+    unsigned k = 2;
+    unsigned m = 800;
 
     int decIterNum = 6;
     bool trained = true;
     double ep0 = 0.1;
     stabilizerCodesType codeType = stabilizerCodesType::GeneralizedBicycle;
-    stabilizerCodes code(n,k,m,codeType);
+    stabilizerCodes code(n, k, m, codeType);
     code.checksymplectic();
 
     int limit1 = 300;
     int limit2 = 45000000;
-//    double ep_list[] = {0.14,0.13,0.12,0.11,0.1,0.09,0.08,0.07,0.06,0.05,0.04,0.03,0.02,0.01,0.009,0.008,0.007,0.006,0.005};
-    double ep_list[] = {0.1,0.09,0.08,0.07,0.06,0.05,0.04,0.03,0.02,0.01,};
-    std::cout<<"%[["<<n<<","<<k<<+"]], "<<m<<" checks, "<<decIterNum<<" iter ";
-    if (trained) std::cout<<"trained"<< std::endl;
-    else std::cout<< std::endl;
+    //    double ep_list[] =
+    //    {0.14,0.13,0.12,0.11,0.1,0.09,0.08,0.07,0.06,0.05,0.04,0.03,0.02,0.01,0.009,0.008,0.007,0.006,0.005};
+    double ep_list[] = {
+        0.1, 0.09, 0.08, 0.07, 0.06, 0.05, 0.04, 0.03, 0.02, 0.01,
+    };
+    std::cout << "%[[" << n << "," << k << +"]], " << m << " checks, " << decIterNum << " iter ";
+    if (trained)
+        std::cout << "trained" << std::endl;
+    else
+        std::cout << std::endl;
 
-    std::cout<<"%collect "<<limit1<<" FE or "<<limit2<<" decoding reached"<< std::endl;
+    std::cout << "%collect " << limit1 << " FE or " << limit2 << " decoding reached" << std::endl;
 
-//    omp_set_num_threads(1);
+    //    omp_set_num_threads(1);
     for (double epsilon : ep_list) {
         double total_decoding = 0;
         double failure = 0;
 
-        #pragma omp parallel
+#pragma omp parallel
         {
-            while (failure <= limit1 && total_decoding<=limit2) {
-                stabilizerCodes code(n,k,m,codeType, trained);
+            while (failure <= limit1 && total_decoding <= limit2) {
+                stabilizerCodes code(n, k, m, codeType, trained);
                 code.addErrorGivenEpsilon(epsilon);
                 std::vector<bool> success;
                 success = code.decode(decIterNum, ep0);
-        #pragma omp critical
+#pragma omp critical
                 {
-                    if (!success[1]) failure += 1;
+                    if (!success[1])
+                        failure += 1;
                     total_decoding += 1;
                 }
             }
         }
-        std::cout << "%FE " << failure << ", total dec. " <<total_decoding << "\\\\" << std::endl;
-        std::cout << epsilon << " " << (failure / total_decoding)  << "\\\\" << std::endl;
+        std::cout << "%FE " << failure << ", total dec. " << total_decoding << "\\\\" << std::endl;
+        std::cout << epsilon << " " << (failure / total_decoding) << "\\\\" << std::endl;
     }
     return 0;
 }

--- a/simulateFER.cpp
+++ b/simulateFER.cpp
@@ -12,7 +12,7 @@ int main() {
     double ep0 = 0.1;
     stabilizerCodesType codeType = stabilizerCodesType::GeneralizedBicycle;
     stabilizerCodes code(n, k, m, codeType);
-    code.checksymplectic();
+    code.check_symplectic();
 
     int limit1 = 300;
     int limit2 = 45000000;
@@ -38,7 +38,7 @@ int main() {
         {
             while (failure <= limit1 && total_decoding <= limit2) {
                 stabilizerCodes code(n, k, m, codeType, trained);
-                code.addErrorGivenEpsilon(epsilon);
+                code.add_error_given_epsilon(epsilon);
                 std::vector<bool> success;
                 success = code.decode(decIterNum, ep0);
 #pragma omp critical

--- a/simulateFER.cpp
+++ b/simulateFER.cpp
@@ -1,5 +1,4 @@
 #include "stabilizerCodes.h"
-#include <iomanip>
 #include <iostream>
 #include <omp.h>
 int main() {

--- a/stabilizerCodes.cpp
+++ b/stabilizerCodes.cpp
@@ -1,6 +1,13 @@
-//
-// Created by sisi on 1/13/23.
-//
+/*
+ * Copyright 2023 Sisi Miao, Communications Engineering Lab @ KIT
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This file accompanies the paper
+ *     S. Miao, A. Schnerring, H. Li and L. Schmalen,
+ *     "Neural belief propagation decoding of quantum LDPC codes using overcomplete check matrices,"
+ *     Proc. IEEE Inform. Theory Workshop (ITW), Saint-Malo, France, Apr. 2023, https://arxiv.org/abs/2212.10245
+ */
 #include "stabilizerCodes.h"
 #include <cmath>
 #include <fstream>

--- a/stabilizerCodes.cpp
+++ b/stabilizerCodes.cpp
@@ -116,9 +116,10 @@ void stabilizerCodes::read_H() {
         codeTypeString = "toric";
     else
         throw std::invalid_argument("unimplemented codetype");
-    std::string filename;
-    filename = "./PCMs/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "/" + codeTypeString +
-               "_" + std::to_string(N) + "_" + std::to_string(K) + "_H_" + std::to_string(M) + ".alist";
+
+    std::string filename = "./PCMs/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "/" +
+                           codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "_H_" +
+                           std::to_string(M) + ".alist";
     // Nvk same shape and Nv, but its value k means the i-th VN being the k-th neigbor of j-th CN
     // Mck same shape and Nv, but its value k means the i-th CN being the k-th neigbor of j-th VN
     std::vector<std::vector<unsigned>> checkValues;
@@ -227,6 +228,7 @@ void stabilizerCodes::read_G() {
         codeTypeString = "toric";
     else
         throw std::invalid_argument("unimplemented codetype");
+
     std::string filename = "./PCMs/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "/" +
                            codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "_G.txt";
     std::string line;
@@ -517,7 +519,7 @@ std::vector<bool> stabilizerCodes::check_success(const double *Taux, const doubl
         for (unsigned j = 0; j < N; j++) {
             check += (trace_inner_product(error[j], G[i][j]) + trace_inner_product(error_hat[j], G[i][j]));
         }
-        if ((check % 2) != 0) {
+        if (check % 2) {
             return success;
         }
     }
@@ -535,9 +537,9 @@ void stabilizerCodes::load_cn_weights() {
         codeTypeString = "toric";
     else
         throw std::invalid_argument("unimplemented codetype");
-    std::string filename;
-    filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "_" +
-               std::to_string(M) + "/weight_cn.txt";
+
+    std::string filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
+                           "_" + std::to_string(M) + "/weight_cn.txt";
     std::vector<std::vector<std::vector<double>>> weight_cn;
     std::string line;
     std::ifstream myfile;
@@ -594,9 +596,9 @@ void stabilizerCodes::load_llr_weights() {
         codeTypeString = "toric";
     else
         throw std::invalid_argument("unimplemented codetype");
-    std::string filename;
-    filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "_" +
-               std::to_string(M) + "/weight_llr.txt";
+
+    std::string filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
+                           "_" + std::to_string(M) + "/weight_llr.txt";
     std::vector<std::vector<double>> weight_llr;
 
     std::string line;
@@ -636,9 +638,9 @@ void stabilizerCodes::load_vn_weights() {
         codeTypeString = "toric";
     else
         throw std::invalid_argument("unimplemented codetype");
-    std::string filename;
-    filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "_" +
-               std::to_string(M) + "/weight_vn.txt";
+
+    std::string filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
+                           "_" + std::to_string(M) + "/weight_vn.txt";
     std::vector<std::vector<std::vector<double>>> weight_cn;
     std::string line;
     std::ifstream myfile;

--- a/stabilizerCodes.cpp
+++ b/stabilizerCodes.cpp
@@ -2,57 +2,75 @@
 // Created by sisi on 1/13/23.
 //
 #include "stabilizerCodes.h"
-stabilizerCodes::stabilizerCodes(unsigned n, unsigned k, unsigned m,stabilizerCodesType codeType, bool trained) {
+stabilizerCodes::stabilizerCodes(unsigned n, unsigned k, unsigned m, stabilizerCodesType codeType, bool trained) {
     mycodetype = codeType;
     N = n;
     K = k;
     M = m;
-    G_rows = N+K;
+    G_rows = N + K;
     mTrained = trained;
-
 }
 
 std::vector<bool> stabilizerCodes::decode(unsigned int L, double epsilon) {
-    if (errorString.empty()) return {true, true};
+    if (errorString.empty())
+        return {true, true};
     readH();
     readG();
-    if (mTrained) {loadWeights_cn(); loadWeights_llr();loadWeights_vn();}
+    if (mTrained) {
+        loadWeights_cn();
+        loadWeights_llr();
+        loadWeights_vn();
+    }
     calSyndrome();
-    error_hat = std::vector<unsigned>(N,0);
+    error_hat = std::vector<unsigned>(N, 0);
     return floodingDecode(L, epsilon, error);
 }
 
 bool stabilizerCodes::checksymplectic() {
     readH();
     readG();
-    unsigned *vec1; vec1 = (unsigned *) malloc(N * sizeof(unsigned *));
-    unsigned *vec2; vec2 = (unsigned *) malloc(N * sizeof(unsigned *));
+    unsigned *vec1;
+    vec1 = (unsigned *)malloc(N * sizeof(unsigned *));
+    unsigned *vec2;
+    vec2 = (unsigned *)malloc(N * sizeof(unsigned *));
 
     for (int rowid = 0; rowid < M; rowid++) {
-        for (int iii = 0; iii < N; iii++) vec1[iii] = 0;
-        for (int j = 0; j < dc[rowid]; j++) { vec1[Mc[rowid][j]] = checkVal[rowid][j];}
-        //check HH^T=0
-        for (int i = 0; i < M; i++) {
-            for (int iii = 0; iii < N; iii++) vec2[iii] = 0;
-            for (int j = 0; j < dc[i]; j++) { vec2[Mc[i][j]] = checkVal[i][j]; }
-            unsigned syn_check = 0;
-            for (int j = 0; j < N; j++) { syn_check  += traceInnerProduct(vec1[j], vec2[j]);}
-            assert ((syn_check % 2) == 0);
+        for (int iii = 0; iii < N; iii++)
+            vec1[iii] = 0;
+        for (int j = 0; j < dc[rowid]; j++) {
+            vec1[Mc[rowid][j]] = checkVal[rowid][j];
         }
-        //check GH^T=0
-        for (int i=0; i<G_rows; i++){
-            unsigned syn_check  = 0;
-            for (int j = 0; j < N; j++) { syn_check  += traceInnerProduct(vec1[j], G[i][j]);}
-            assert ((syn_check  % 2) == 0);
+        // check HH^T=0
+        for (int i = 0; i < M; i++) {
+            for (int iii = 0; iii < N; iii++)
+                vec2[iii] = 0;
+            for (int j = 0; j < dc[i]; j++) {
+                vec2[Mc[i][j]] = checkVal[i][j];
+            }
+            unsigned syn_check = 0;
+            for (int j = 0; j < N; j++) {
+                syn_check += traceInnerProduct(vec1[j], vec2[j]);
+            }
+            assert((syn_check % 2) == 0);
+        }
+        // check GH^T=0
+        for (int i = 0; i < G_rows; i++) {
+            unsigned syn_check = 0;
+            for (int j = 0; j < N; j++) {
+                syn_check += traceInnerProduct(vec1[j], G[i][j]);
+            }
+            assert((syn_check % 2) == 0);
         }
     }
-    free(vec1);free(vec2);
-    std::cout<<"check symplectic ok"<<std::endl;
+    free(vec1);
+    free(vec2);
+    std::cout << "check symplectic ok" << std::endl;
     return true;
 }
 
 void stabilizerCodes::addErrorGivenEpsilon(double epsilon) {
-    error.clear();errorString.clear();
+    error.clear();
+    errorString.clear();
     std::uniform_real_distribution<double> dist(0, 1);
 
     auto res = std::random_device()();
@@ -62,64 +80,93 @@ void stabilizerCodes::addErrorGivenEpsilon(double epsilon) {
 
     for (unsigned i = 0; i < N; i++) {
         double rndValue = roll();
-        if (rndValue < epsilon / 3) {error.push_back(1);errorString.emplace_back("X" + std::to_string(i));}
-        else if (rndValue < epsilon * 2 / 3) {error.push_back(2);errorString.emplace_back("Z" + std::to_string(i));}
-        else if (rndValue < epsilon) {error.push_back(3);errorString.emplace_back("Y" + std::to_string(i));}
-        else {error.push_back(0);}
+        if (rndValue < epsilon / 3) {
+            error.push_back(1);
+            errorString.emplace_back("X" + std::to_string(i));
+        } else if (rndValue < epsilon * 2 / 3) {
+            error.push_back(2);
+            errorString.emplace_back("Z" + std::to_string(i));
+        } else if (rndValue < epsilon) {
+            error.push_back(3);
+            errorString.emplace_back("Y" + std::to_string(i));
+        } else {
+            error.push_back(0);
+        }
     }
 }
 
-void stabilizerCodes::addErrorGivenPositions(int *pos, int *error, int size) {
-
-}
+void stabilizerCodes::addErrorGivenPositions(int *pos, int *error, int size) {}
 
 void stabilizerCodes::readH() {
     std::string codeTypeString;
-    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)codeTypeString = "GB";
-    else if (mycodetype == stabilizerCodesType::HpergraphProduct)codeTypeString = "HP";
-    else if (mycodetype == stabilizerCodesType::toric)codeTypeString = "toric";
-    else throw std::invalid_argument( "unimplemented codetype" );
+    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)
+        codeTypeString = "GB";
+    else if (mycodetype == stabilizerCodesType::HpergraphProduct)
+        codeTypeString = "HP";
+    else if (mycodetype == stabilizerCodesType::toric)
+        codeTypeString = "toric";
+    else
+        throw std::invalid_argument("unimplemented codetype");
     std::string filename;
-    filename = "./PCMs/"+codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +"/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
-                               "_H_"+std::to_string(M)+".alist";
-    //Nvk same shape and Nv, but its value k means the i-th VN being the k-th neigbor of j-th CN
-    //Mck same shape and Nv, but its value k means the i-th CN being the k-th neigbor of j-th VN
+    filename = "./PCMs/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "/" + codeTypeString +
+               "_" + std::to_string(N) + "_" + std::to_string(K) + "_H_" + std::to_string(M) + ".alist";
+    // Nvk same shape and Nv, but its value k means the i-th VN being the k-th neigbor of j-th CN
+    // Mck same shape and Nv, but its value k means the i-th CN being the k-th neigbor of j-th VN
     std::vector<std::vector<unsigned>> checkValues;
     std::vector<std::vector<unsigned>> VariableValues;
 
-    std::string line;std::ifstream myfile;myfile.open(filename);
+    std::string line;
+    std::ifstream myfile;
+    myfile.open(filename);
     if (myfile.is_open()) {
-        //first line, n k
-        getline(myfile, line, ' ');unsigned n = std::stoi(line);
-        getline(myfile, line);unsigned m = std::stoi(line);
+        // first line, n k
+        getline(myfile, line, ' ');
+        unsigned n = std::stoi(line);
+        getline(myfile, line);
+        unsigned m = std::stoi(line);
 
-        assert(n==N);assert(M=m);
-        //second line max dv and dc
-        getline(myfile, line, ' '); maxDv = std::stoi(line);
-        getline(myfile, line); maxDc = std::stoi(line);
+        assert(n == N);
+        assert(M = m);
+        // second line max dv and dc
+        getline(myfile, line, ' ');
+        maxDv = std::stoi(line);
+        getline(myfile, line);
+        maxDc = std::stoi(line);
 
-        //third line, dv degrees
+        // third line, dv degrees
         for (int i = 0; i < n - 1; i++) {
-            getline(myfile, line, ' ');dv.push_back(std::stoi(line));Nvk.emplace_back();
+            getline(myfile, line, ' ');
+            dv.push_back(std::stoi(line));
+            Nvk.emplace_back();
         }
-        Nvk.emplace_back();getline(myfile, line);dv.push_back(std::stoi(line));
+        Nvk.emplace_back();
+        getline(myfile, line);
+        dv.push_back(std::stoi(line));
 
-        //forth line, dc degrees
+        // forth line, dc degrees
         for (int i = 0; i < m - 1; i++) {
-            getline(myfile, line, ' ');dc.push_back(std::stoi(line));Mck.emplace_back();
+            getline(myfile, line, ' ');
+            dc.push_back(std::stoi(line));
+            Mck.emplace_back();
         }
-        Mck.emplace_back();getline(myfile, line);dc.push_back(std::stoi(line));
+        Mck.emplace_back();
+        getline(myfile, line);
+        dc.push_back(std::stoi(line));
 
-        //fifth to n+5-th line, dv neighbors
+        // fifth to n+5-th line, dv neighbors
         for (unsigned i = 0; i < n; i++) {
             Nv.emplace_back(dv[i], 0);
             for (unsigned j = 0; j < dv[i] - 1; j++) {
-                getline(myfile, line, ' ');Nv[i][j] = std::stoi(line) - 1;Mck[Nv[i][j]].push_back(j);
+                getline(myfile, line, ' ');
+                Nv[i][j] = std::stoi(line) - 1;
+                Mck[Nv[i][j]].push_back(j);
             }
-            getline(myfile, line);Nv[i][dv[i] - 1] = std::stoi(line) - 1;Mck[Nv[i][dv[i] - 1]].push_back(dv[i] - 1);
+            getline(myfile, line);
+            Nv[i][dv[i] - 1] = std::stoi(line) - 1;
+            Mck[Nv[i][dv[i] - 1]].push_back(dv[i] - 1);
         }
 
-        //n+6-th to n+6+m-th line, dc neighbors
+        // n+6-th to n+6+m-th line, dc neighbors
         for (unsigned i = 0; i < m; i++) {
             Mc.emplace_back(dc[i], 0);
             for (unsigned j = 0; j < dc[i] - 1; j++) {
@@ -127,104 +174,143 @@ void stabilizerCodes::readH() {
                 Mc[i][j] = std::stoi(line) - 1;
                 Nvk[Mc[i][j]].push_back(j);
             }
-            getline(myfile, line);Mc[i][dc[i] - 1] = std::stoi(line) - 1;Nvk[Mc[i][dc[i] - 1]].push_back(dc[i] - 1);
+            getline(myfile, line);
+            Mc[i][dc[i] - 1] = std::stoi(line) - 1;
+            Nvk[Mc[i][dc[i] - 1]].push_back(dc[i] - 1);
         }
-        //n+6+m+1-th to n+6+m+n-th line, value of each row
+        // n+6+m+1-th to n+6+m+n-th line, value of each row
         for (unsigned i = 0; i < m; i++) {
             checkValues.emplace_back(dc[i], 0);
             for (unsigned j = 0; j < dc[i] - 1; j++) {
-                getline(myfile, line, ' ');checkValues[i][j] = std::stoi(line);
+                getline(myfile, line, ' ');
+                checkValues[i][j] = std::stoi(line);
             }
-            getline(myfile, line);checkValues[i][dc[i] - 1] = std::stoi(line);
+            getline(myfile, line);
+            checkValues[i][dc[i] - 1] = std::stoi(line);
         }
-        //last lines, value of each column
+        // last lines, value of each column
         for (unsigned i = 0; i < n; i++) {
             VariableValues.emplace_back(dv[i], 0);
             for (unsigned j = 0; j < dv[i] - 1; j++) {
-                getline(myfile, line, ' '); VariableValues[i][j] = std::stoi(line);
+                getline(myfile, line, ' ');
+                VariableValues[i][j] = std::stoi(line);
             }
-            getline(myfile, line);VariableValues[i][dv[i] - 1] = std::stoi(line);
+            getline(myfile, line);
+            VariableValues[i][dv[i] - 1] = std::stoi(line);
         }
         myfile.close();
-    }
-    else
+    } else
         std::cout << "Unable to open file" << std::endl;
-    checkVal = checkValues; varVal = VariableValues;
+    checkVal = checkValues;
+    varVal = VariableValues;
 }
-void stabilizerCodes::readG(){
+void stabilizerCodes::readG() {
     std::string codeTypeString;
-    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)codeTypeString = "GB";
-    else if (mycodetype == stabilizerCodesType::HpergraphProduct)codeTypeString = "HP";
-    else if (mycodetype == stabilizerCodesType::toric)codeTypeString = "toric";
-    else throw std::invalid_argument( "unimplemented codetype" );
-    std::string filename = "./PCMs/"+ codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K)+"/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
-                           "_G.txt";
-    std::string line;std::ifstream myfile;myfile.open(filename);
+    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)
+        codeTypeString = "GB";
+    else if (mycodetype == stabilizerCodesType::HpergraphProduct)
+        codeTypeString = "HP";
+    else if (mycodetype == stabilizerCodesType::toric)
+        codeTypeString = "toric";
+    else
+        throw std::invalid_argument("unimplemented codetype");
+    std::string filename = "./PCMs/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "/" +
+                           codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "_G.txt";
+    std::string line;
+    std::ifstream myfile;
+    myfile.open(filename);
     if (myfile.is_open()) {
         for (unsigned i = 0; i < G_rows; i++) {
-            std::vector<unsigned> row(N,0);
+            std::vector<unsigned> row(N, 0);
             for (unsigned j = 0; j < N - 1; j++) {
-                getline(myfile, line, ' '); row[j] = std::stoi(line) ;
+                getline(myfile, line, ' ');
+                row[j] = std::stoi(line);
             }
-            getline(myfile, line);row[N-1] = std::stoi(line);
+            getline(myfile, line);
+            row[N - 1] = std::stoi(line);
             G.push_back(row);
         }
         myfile.close();
-    }
-    else std::cout << "Unable to open file" << std::endl;
-
+    } else
+        std::cout << "Unable to open file" << std::endl;
 }
 double stabilizerCodes::bielief_quantize(double Tau, double Tau1, double Tau2) {
     double nom = log1p(exp(-1.0 * Tau));
     double denom = std::max(-1.0 * Tau1, -1.0 * Tau2) + log1p(exp(-1.0 * fabs((Tau1 - Tau2))));
     double ret_val = nom - denom;
-    assert (!std::isnan(ret_val));
+    assert(!std::isnan(ret_val));
     return ret_val;
 }
 
 unsigned stabilizerCodes::traceInnerProduct(unsigned int a, unsigned int b) {
-    if (a==0 || b==0)
+    if (a == 0 || b == 0)
         return 0;
-    if (a==b)
+    if (a == b)
         return 0;
     return 1;
 }
 
-//TODO: reimplement flooding decode
+// TODO: reimplement flooding decode
 std::vector<bool> stabilizerCodes::floodingDecode(unsigned int L, double epsilon, const std::vector<unsigned> error) {
-    double num_elements_in_H = 0;for (int i=0; i<N; i++){num_elements_in_H+=dv[i];}
+    double num_elements_in_H = 0;
+    for (int i = 0; i < N; i++) {
+        num_elements_in_H += dv[i];
+    }
     std::vector<bool> success(2, false);
     double L0 = log(3.0 * (1 - epsilon) / epsilon);
 
     double lambda0 = log((1 + exp(-L0)) / (exp(-L0) + exp(-L0)));
-//
-    //Allocate memory for messages
-    double **mc2v, **mv2c;mc2v = (double **) malloc(M * sizeof(double *));mv2c = (double **) malloc(N * sizeof(double *));
-    double *Taux, *Tauz, *Tauy;Taux = (double *) malloc(N * sizeof(double *));Tauz = (double *) malloc(N * sizeof(double *));Tauy = (double *) malloc(N * sizeof(double *));
-    double *phi_msg;phi_msg = (double *) malloc(maxDc * sizeof(double *));
-    for (int i = 0; i < M; i++) {mc2v[i] = (double *) malloc(dc[i] * sizeof(double *));for (int j = 0; j < dc[i]; j++)mc2v[i][j] = 0;}
-    if (mTrained){
+    //
+    // Allocate memory for messages
+    double **mc2v, **mv2c;
+    mc2v = (double **)malloc(M * sizeof(double *));
+    mv2c = (double **)malloc(N * sizeof(double *));
+    double *Taux, *Tauz, *Tauy;
+    Taux = (double *)malloc(N * sizeof(double *));
+    Tauz = (double *)malloc(N * sizeof(double *));
+    Tauy = (double *)malloc(N * sizeof(double *));
+    double *phi_msg;
+    phi_msg = (double *)malloc(maxDc * sizeof(double *));
+    for (int i = 0; i < M; i++) {
+        mc2v[i] = (double *)malloc(dc[i] * sizeof(double *));
+        for (int j = 0; j < dc[i]; j++)
+            mc2v[i][j] = 0;
+    }
+    if (mTrained) {
         for (int i = 0; i < N; i++) {
-            mv2c[i] = (double *) malloc(dv[i] * sizeof(double *));
-            for (int j = 0; j < dv[i]; j++){
-                double lam = log((1 + exp(-L0*weights_llr[0][i])) / (exp(-L0*weights_llr[0][i]) + exp(-L0*weights_llr[0][i])));
-                mv2c[i][j] = lam*= weights_vn[0][i][j];
+            mv2c[i] = (double *)malloc(dv[i] * sizeof(double *));
+            for (int j = 0; j < dv[i]; j++) {
+                double lam = log((1 + exp(-L0 * weights_llr[0][i])) /
+                                 (exp(-L0 * weights_llr[0][i]) + exp(-L0 * weights_llr[0][i])));
+                mv2c[i][j] = lam *= weights_vn[0][i][j];
+            }
+        }
+    } else {
+        for (int i = 0; i < N; i++) {
+            mv2c[i] = (double *)malloc(dv[i] * sizeof(double *));
+            for (int j = 0; j < dv[i]; j++) {
+                mv2c[i][j] = lambda0;
             }
         }
     }
-    else{
-        for (int i = 0; i < N; i++) {mv2c[i] = (double *) malloc(dv[i] * sizeof(double *));for (int j = 0; j < dv[i]; j++){mv2c[i][j] = lambda0;}}
+    if (print_msg) {
+        for (unsigned r = 0; r < 1; r++) {
+            for (unsigned c = 0; c < dv[r]; c++) {
+                std::cout << mv2c[r][c] << " ";
+            }
+            std::cout << std::endl;
+        }
+        std::cout << std::endl;
     }
-    if (print_msg){for (unsigned r=0; r<1; r++){for (unsigned c=0; c<dv[r]; c++){std::cout<<mv2c[r][c]<<" ";}std::cout<<std::endl;}std::cout<<std::endl;}
 
-    //start decoding
+    // start decoding
     for (unsigned decIter = 0; decIter < L; decIter++) {
-        //CN update, for i-th check node, calculate mc2v
+        // CN update, for i-th check node, calculate mc2v
         double sum_cn_msg = 0;
         for (int i = 0; i < M; i++) {
             double phi_sum = 0;
             double sign_prod = (syn[i] == 0 ? 1.0 : -1.0);
-            //Sum-Product
+            // Sum-Product
             for (int j = 0; j < dc[i]; j++) {
                 if (mv2c[Mc[i][j]][Mck[i][j]] != 0)
                     phi_msg[j] = -1.0 * log(tanh(fabs(mv2c[Mc[i][j]][Mck[i][j]]) / 2.0));
@@ -240,65 +326,124 @@ std::vector<bool> stabilizerCodes::floodingDecode(unsigned int L, double epsilon
                 if (phi_extrinsic_phi_sum != 0)
                     phi_phi_sum = -1.0 * log(tanh(phi_extrinsic_phi_sum / 2.0));
                 mc2v[i][j] = phi_phi_sum * sign_prod / (mv2c[Mc[i][j]][Mck[i][j]] >= 0.0 ? 1.0 : -1.0);
-                if (mTrained && decIter<trained_iter) mc2v[i][j] *= weights_cn[decIter][i][j];
-                sum_cn_msg+=fabs(mc2v[i][j]);
-                assert (!std::isnan(mc2v[i][j]));assert (!std::isinf(mc2v[i][j]));
+                if (mTrained && decIter < trained_iter)
+                    mc2v[i][j] *= weights_cn[decIter][i][j];
+                sum_cn_msg += fabs(mc2v[i][j]);
+                assert(!std::isnan(mc2v[i][j]));
+                assert(!std::isinf(mc2v[i][j]));
             }
-
         }
-        double ave_cn_msg = sum_cn_msg/num_elements_in_H;
-        if (print_msg)
-        {std::cout<<"CN messages"<<std::endl; for (unsigned r=0; r<1; r++){for (unsigned c=0; c<dc[r]; c++){std::cout<<mc2v[r][c]<<" ";}std::cout<<std::endl;}std::cout<<std::endl;}
-        //VN update
+        double ave_cn_msg = sum_cn_msg / num_elements_in_H;
+        if (print_msg) {
+            std::cout << "CN messages" << std::endl;
+            for (unsigned r = 0; r < 1; r++) {
+                for (unsigned c = 0; c < dc[r]; c++) {
+                    std::cout << mc2v[r][c] << " ";
+                }
+                std::cout << std::endl;
+            }
+            std::cout << std::endl;
+        }
+        // VN update
         for (unsigned Vidx = 0; Vidx < N; Vidx++) {
-            Taux[Vidx] = L0;Tauz[Vidx] = L0;Tauy[Vidx] = L0;
-            if (mTrained && decIter<trained_iter){Taux[Vidx]*=weights_llr[decIter+1][Vidx];Tauy[Vidx]*=weights_llr[decIter+1][Vidx];Tauz[Vidx]*=weights_llr[decIter+1][Vidx];}
-            double Tauxi;double Tauyi;double Tauzi;
+            Taux[Vidx] = L0;
+            Tauz[Vidx] = L0;
+            Tauy[Vidx] = L0;
+            if (mTrained && decIter < trained_iter) {
+                Taux[Vidx] *= weights_llr[decIter + 1][Vidx];
+                Tauy[Vidx] *= weights_llr[decIter + 1][Vidx];
+                Tauz[Vidx] *= weights_llr[decIter + 1][Vidx];
+            }
+            double Tauxi;
+            double Tauyi;
+            double Tauzi;
 
-            //jj, index of the neighboring CNs of the VN, sum up the CN messages
-            for (int jj = 0; jj < dv[Vidx]; jj++)
-            {
-                if (varVal[Vidx][jj]==1){Tauz[Vidx] += mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];Tauy[Vidx] += mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];}
-                else if (varVal[Vidx][jj]==2){Taux[Vidx] += mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];Tauy[Vidx] += mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];}
-                else if (varVal[Vidx][jj]==3){Taux[Vidx] += mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];Tauz[Vidx] += mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];}
-                else throw std::invalid_argument( "something is wrong" );
+            // jj, index of the neighboring CNs of the VN, sum up the CN messages
+            for (int jj = 0; jj < dv[Vidx]; jj++) {
+                if (varVal[Vidx][jj] == 1) {
+                    Tauz[Vidx] += mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];
+                    Tauy[Vidx] += mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];
+                } else if (varVal[Vidx][jj] == 2) {
+                    Taux[Vidx] += mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];
+                    Tauy[Vidx] += mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];
+                } else if (varVal[Vidx][jj] == 3) {
+                    Taux[Vidx] += mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];
+                    Tauz[Vidx] += mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];
+                } else
+                    throw std::invalid_argument("something is wrong");
             }
 
-            for (int jj = 0; jj < dv[Vidx]; jj++) {double temp;
-                if (varVal[Vidx][jj]==1){Tauxi = Taux[Vidx];Tauzi = Tauz[Vidx] - mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];Tauyi = Tauy[Vidx] - mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];temp = bielief_quantize(Tauxi, Tauyi, Tauzi);}
-                else if (varVal[Vidx][jj]==2){Tauxi = Taux[Vidx]- mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];Tauzi = Tauz[Vidx];Tauyi = Tauy[Vidx] - mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];temp = bielief_quantize(Tauzi, Tauyi, Tauxi);}
-                else if (varVal[Vidx][jj]==3){Tauxi = Taux[Vidx] - mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];Tauzi = Tauz[Vidx] - mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];Tauyi = Tauy[Vidx];temp = bielief_quantize(Tauyi, Tauxi, Tauzi);}
-                else throw std::invalid_argument( "something is wrong" );
+            for (int jj = 0; jj < dv[Vidx]; jj++) {
+                double temp;
+                if (varVal[Vidx][jj] == 1) {
+                    Tauxi = Taux[Vidx];
+                    Tauzi = Tauz[Vidx] - mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];
+                    Tauyi = Tauy[Vidx] - mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];
+                    temp = bielief_quantize(Tauxi, Tauyi, Tauzi);
+                } else if (varVal[Vidx][jj] == 2) {
+                    Tauxi = Taux[Vidx] - mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];
+                    Tauzi = Tauz[Vidx];
+                    Tauyi = Tauy[Vidx] - mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];
+                    temp = bielief_quantize(Tauzi, Tauyi, Tauxi);
+                } else if (varVal[Vidx][jj] == 3) {
+                    Tauxi = Taux[Vidx] - mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];
+                    Tauzi = Tauz[Vidx] - mc2v[Nv[Vidx][jj]][Nvk[Vidx][jj]];
+                    Tauyi = Tauy[Vidx];
+                    temp = bielief_quantize(Tauyi, Tauxi, Tauzi);
+                } else
+                    throw std::invalid_argument("something is wrong");
                 double limit = 60;
                 if (temp > limit)
                     mv2c[Vidx][jj] = limit;
                 else if (temp < -limit)
                     mv2c[Vidx][jj] = -limit;
-                else mv2c[Vidx][jj] = temp;
-                assert (!std::isnan(mv2c[Vidx][jj]));assert (!std::isinf(mv2c[Vidx][jj]));
-                if (mTrained && decIter<trained_iter) mv2c[Vidx][jj] *= weights_vn[decIter+1][Vidx][jj];
+                else
+                    mv2c[Vidx][jj] = temp;
+                assert(!std::isnan(mv2c[Vidx][jj]));
+                assert(!std::isinf(mv2c[Vidx][jj]));
+                if (mTrained && decIter < trained_iter)
+                    mv2c[Vidx][jj] *= weights_vn[decIter + 1][Vidx][jj];
             }
         }
-        if (print_msg){
-            std::cout<<"Taux, Tauy, Tauz"<<std::endl;
-            for (unsigned i=0; i<N; i++) std::cout<<Taux[i]<<" ";std::cout<<std::endl;
-            for (unsigned i=0; i<N; i++) std::cout<<Tauy[i]<<" ";std::cout<<std::endl;
-            for (unsigned i=0; i<N; i++) std::cout<<Tauz[i]<<" ";std::cout<<std::endl;
-            std::cout<<"VN messages"<<std::endl;
-            for (unsigned r=0; r<1; r++){for (unsigned c=0; c<dv[r]; c++){std::cout<<mv2c[r][c]<<" ";}std::cout<<std::endl;}std::cout<<std::endl;
+        if (print_msg) {
+            std::cout << "Taux, Tauy, Tauz" << std::endl;
+            for (unsigned i = 0; i < N; i++)
+                std::cout << Taux[i] << " ";
+            std::cout << std::endl;
+            for (unsigned i = 0; i < N; i++)
+                std::cout << Tauy[i] << " ";
+            std::cout << std::endl;
+            for (unsigned i = 0; i < N; i++)
+                std::cout << Tauz[i] << " ";
+            std::cout << std::endl;
+            std::cout << "VN messages" << std::endl;
+            for (unsigned r = 0; r < 1; r++) {
+                for (unsigned c = 0; c < dv[r]; c++) {
+                    std::cout << mv2c[r][c] << " ";
+                }
+                std::cout << std::endl;
+            }
+            std::cout << std::endl;
         }
         success = checkSucess(Taux, Tauy, Tauz);
         if (success[0])
             break;
     }
 
-    free(Taux);free(Tauy);free(Tauz);free(phi_msg);
-    for (int i = 0; i < M; i++) {free(mc2v[i]);}for (int i = 0; i < N; i++) {free(mv2c[i]);}
-    free(mc2v);free(mv2c);
+    free(Taux);
+    free(Tauy);
+    free(Tauz);
+    free(phi_msg);
+    for (int i = 0; i < M; i++) {
+        free(mc2v[i]);
+    }
+    for (int i = 0; i < N; i++) {
+        free(mv2c[i]);
+    }
+    free(mc2v);
+    free(mv2c);
     return success;
 }
-
-
 
 void stabilizerCodes::calSyndrome() {
     for (int i = 0; i < M; i++) {
@@ -312,106 +457,137 @@ void stabilizerCodes::calSyndrome() {
 
 std::vector<bool> stabilizerCodes::checkSucess(const double *Taux, const double *Tauy, const double *Tauz) {
     std::vector<bool> success(2, false);
-    error_hat = std::vector<unsigned>(N,0);
+    error_hat = std::vector<unsigned>(N, 0);
     errorHatString.clear();
     for (int i = 0; i < N; i++) {
-        if (Taux[i] > 0 && Tauy[i] > 0 && Tauz[i] > 0) {error_hat[i] = 0;}
-        else if (Taux[i] < Tauy[i] && Taux[i] < Tauz[i]) {error_hat[i] = 1;errorHatString.emplace_back("X" + std::to_string(i));}
-        else if (Tauz[i] < Taux[i] && Tauz[i] < Tauy[i]) {error_hat[i] = 2;errorHatString.emplace_back("Z" + std::to_string(i));}
-        else {error_hat[i] = 3;errorHatString.emplace_back("Y" + std::to_string(i));}
+        if (Taux[i] > 0 && Tauy[i] > 0 && Tauz[i] > 0) {
+            error_hat[i] = 0;
+        } else if (Taux[i] < Tauy[i] && Taux[i] < Tauz[i]) {
+            error_hat[i] = 1;
+            errorHatString.emplace_back("X" + std::to_string(i));
+        } else if (Tauz[i] < Taux[i] && Tauz[i] < Tauy[i]) {
+            error_hat[i] = 2;
+            errorHatString.emplace_back("Z" + std::to_string(i));
+        } else {
+            error_hat[i] = 3;
+            errorHatString.emplace_back("Y" + std::to_string(i));
+        }
     }
     for (int i = 0; i < M; i++) {
-        unsigned check = 0;for (int j = 0; j < dc[i]; j++) {check += traceInnerProduct(error_hat[Mc[i][j]], checkVal[i][j]);}
-        if ((check % 2) != syn[i]) {return success;}}
+        unsigned check = 0;
+        for (int j = 0; j < dc[i]; j++) {
+            check += traceInnerProduct(error_hat[Mc[i][j]], checkVal[i][j]);
+        }
+        if ((check % 2) != syn[i]) {
+            return success;
+        }
+    }
     success[0] = true;
     for (int i = 0; i < G_rows; i++) {
-        unsigned check = 0;for (int j = 0; j < N; j++) {check += (traceInnerProduct(error[j], G[i][j])+traceInnerProduct(error_hat[j], G[i][j]));}
-        if ((check % 2) != 0) {return success;}}
+        unsigned check = 0;
+        for (int j = 0; j < N; j++) {
+            check += (traceInnerProduct(error[j], G[i][j]) + traceInnerProduct(error_hat[j], G[i][j]));
+        }
+        if ((check % 2) != 0) {
+            return success;
+        }
+    }
     success[1] = true;
     return success;
 }
 
 void stabilizerCodes::loadWeights_cn() {
     std::string codeTypeString;
-    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)codeTypeString = "GB";
-    else if (mycodetype == stabilizerCodesType::HpergraphProduct)codeTypeString = "HP";
-    else if (mycodetype == stabilizerCodesType::toric)codeTypeString = "toric";
-    else throw std::invalid_argument( "unimplemented codetype" );
+    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)
+        codeTypeString = "GB";
+    else if (mycodetype == stabilizerCodesType::HpergraphProduct)
+        codeTypeString = "HP";
+    else if (mycodetype == stabilizerCodesType::toric)
+        codeTypeString = "toric";
+    else
+        throw std::invalid_argument("unimplemented codetype");
     std::string filename;
-    filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
-               "_"+std::to_string(M)+"/weight_cn.txt";
+    filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "_" +
+               std::to_string(M) + "/weight_cn.txt";
     std::vector<std::vector<std::vector<double>>> weight_cn;
-    std::string line;std::ifstream myfile;myfile.open(filename);
+    std::string line;
+    std::ifstream myfile;
+    myfile.open(filename);
     unsigned dec_iter;
     if (myfile.is_open()) {
-        //first line, number of iterations
+        // first line, number of iterations
         getline(myfile, line);
         dec_iter = std::stoi(line);
         trained_iter = dec_iter;
-        //second line, n m
-        getline(myfile, line, ' ');unsigned n = std::stod(line);
-        getline(myfile, line);unsigned m = std::stoi(line);
+        // second line, n m
+        getline(myfile, line, ' ');
+        unsigned n = std::stod(line);
+        getline(myfile, line);
+        unsigned m = std::stoi(line);
 
-        assert(n==N);assert(M=m);
-        //rest of the lines, value of each rows of all iterations
-        for (unsigned iter=0; iter<dec_iter; iter++) {
+        assert(n == N);
+        assert(M = m);
+        // rest of the lines, value of each rows of all iterations
+        for (unsigned iter = 0; iter < dec_iter; iter++) {
             weight_cn.emplace_back();
         }
-        for (unsigned iter=0; iter<dec_iter; iter++){
+        for (unsigned iter = 0; iter < dec_iter; iter++) {
             std::vector<std::vector<double>> weight_cn_tmp;
             for (unsigned i = 0; i < m; i++) {
-                std::vector<double> weight_cn_row(dc[i],0);
+                std::vector<double> weight_cn_row(dc[i], 0);
                 for (unsigned j = 0; j < dc[i] - 1; j++) {
-                    getline(myfile, line, ' ');weight_cn_row[j] = std::stod(line);
+                    getline(myfile, line, ' ');
+                    weight_cn_row[j] = std::stod(line);
                 }
-                getline(myfile, line);weight_cn_row[dc[i] - 1] = std::stod(line);
+                getline(myfile, line);
+                weight_cn_row[dc[i] - 1] = std::stod(line);
                 weight_cn_tmp.push_back(weight_cn_row);
             }
             weights_cn.push_back(weight_cn_tmp);
         }
 
         myfile.close();
-    }
-    else
+    } else
         std::cout << "Unable to open file" << std::endl;
-
-
 }
-
 
 void stabilizerCodes::loadWeights_llr() {
     std::string codeTypeString;
-    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)codeTypeString = "GB";
-    else if (mycodetype == stabilizerCodesType::HpergraphProduct)codeTypeString = "HP";
-    else if (mycodetype == stabilizerCodesType::toric)codeTypeString = "toric";
-    else throw std::invalid_argument( "unimplemented codetype" );
+    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)
+        codeTypeString = "GB";
+    else if (mycodetype == stabilizerCodesType::HpergraphProduct)
+        codeTypeString = "HP";
+    else if (mycodetype == stabilizerCodesType::toric)
+        codeTypeString = "toric";
+    else
+        throw std::invalid_argument("unimplemented codetype");
     std::string filename;
-    filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
-               "_"+std::to_string(M)+"/weight_llr.txt";
+    filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "_" +
+               std::to_string(M) + "/weight_llr.txt";
     std::vector<std::vector<double>> weight_llr;
 
-    std::string line;std::ifstream myfile;myfile.open(filename);
+    std::string line;
+    std::ifstream myfile;
+    myfile.open(filename);
     unsigned dec_iter;
     if (myfile.is_open()) {
-        //first line, number of iterations
+        // first line, number of iterations
         getline(myfile, line);
         dec_iter = std::stoi(line);
 
-
-        //rest of the lines, value of all llr weights
-        for (unsigned iter=0; iter<dec_iter; iter++){
-            weight_llr.emplace_back(N,0);
-            for (unsigned i = 0; i < N-1; i++) {
+        // rest of the lines, value of all llr weights
+        for (unsigned iter = 0; iter < dec_iter; iter++) {
+            weight_llr.emplace_back(N, 0);
+            for (unsigned i = 0; i < N - 1; i++) {
                 getline(myfile, line, ' ');
                 weight_llr[iter][i] = std::stod(line);
             }
-                getline(myfile, line);weight_llr[iter][N - 1] = std::stod(line);
-
+            getline(myfile, line);
+            weight_llr[iter][N - 1] = std::stod(line);
         }
 
         myfile.close();
-    }
-    else
+    } else
         std::cout << "Unable to open file" << std::endl;
 
     weights_llr = weight_llr;
@@ -419,45 +595,54 @@ void stabilizerCodes::loadWeights_llr() {
 
 void stabilizerCodes::loadWeights_vn() {
     std::string codeTypeString;
-    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)codeTypeString = "GB";
-    else if (mycodetype == stabilizerCodesType::HpergraphProduct)codeTypeString = "HP";
-    else if (mycodetype == stabilizerCodesType::toric)codeTypeString = "toric";
-    else throw std::invalid_argument( "unimplemented codetype" );
+    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)
+        codeTypeString = "GB";
+    else if (mycodetype == stabilizerCodesType::HpergraphProduct)
+        codeTypeString = "HP";
+    else if (mycodetype == stabilizerCodesType::toric)
+        codeTypeString = "toric";
+    else
+        throw std::invalid_argument("unimplemented codetype");
     std::string filename;
-    filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
-               "_"+std::to_string(M)+"/weight_vn.txt";
+    filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "_" +
+               std::to_string(M) + "/weight_vn.txt";
     std::vector<std::vector<std::vector<double>>> weight_cn;
-    std::string line;std::ifstream myfile;myfile.open(filename);
+    std::string line;
+    std::ifstream myfile;
+    myfile.open(filename);
     unsigned dec_iter;
     if (myfile.is_open()) {
-        //first line, number of iterations
+        // first line, number of iterations
         getline(myfile, line);
         dec_iter = std::stoi(line);
-        //second line, n m
-        getline(myfile, line, ' ');unsigned n = std::stod(line);
-        getline(myfile, line);unsigned m = std::stoi(line);
+        // second line, n m
+        getline(myfile, line, ' ');
+        unsigned n = std::stod(line);
+        getline(myfile, line);
+        unsigned m = std::stoi(line);
 
-        assert(n==N);assert(M=m);
-        //rest of the lines, value of each rows of all iterations
-        for (unsigned iter=0; iter<dec_iter; iter++) {
+        assert(n == N);
+        assert(M = m);
+        // rest of the lines, value of each rows of all iterations
+        for (unsigned iter = 0; iter < dec_iter; iter++) {
             weight_cn.emplace_back();
         }
-        for (unsigned iter=0; iter<dec_iter; iter++){
+        for (unsigned iter = 0; iter < dec_iter; iter++) {
             std::vector<std::vector<double>> weight_cn_tmp;
             for (unsigned i = 0; i < n; i++) {
-                std::vector<double> weight_cn_row(dv[i],0);
+                std::vector<double> weight_cn_row(dv[i], 0);
                 for (unsigned j = 0; j < dv[i] - 1; j++) {
-                    getline(myfile, line, ' ');weight_cn_row[j] = std::stod(line);
+                    getline(myfile, line, ' ');
+                    weight_cn_row[j] = std::stod(line);
                 }
-                getline(myfile, line);weight_cn_row[dv[i] - 1] = std::stod(line);
+                getline(myfile, line);
+                weight_cn_row[dv[i] - 1] = std::stod(line);
                 weight_cn_tmp.push_back(weight_cn_row);
             }
             weights_vn.push_back(weight_cn_tmp);
         }
 
         myfile.close();
-    }
-    else
+    } else
         std::cout << "Unable to open file" << std::endl;
 }
-

--- a/stabilizerCodes.cpp
+++ b/stabilizerCodes.cpp
@@ -4,7 +4,6 @@
 #include "stabilizerCodes.h"
 #include <cmath>
 #include <fstream>
-#include <functional>
 #include <iostream>
 #include <random>
 
@@ -86,7 +85,7 @@ void stabilizerCodes::add_error_given_epsilon(double epsilon) {
     auto res = std::random_device()();
     std::ranlux24 generator(res);
     std::uniform_real_distribution<double> distribution(0, 1);
-    auto roll = std::bind(distribution, generator);
+    auto roll = [&distribution, &generator]() { return distribution(generator); };
 
     for (unsigned i = 0; i < N; i++) {
         double rndValue = roll();

--- a/stabilizerCodes.h
+++ b/stabilizerCodes.h
@@ -1,6 +1,13 @@
-//
-// Created by sisi on 1/13/23.
-//
+/*
+ * Copyright 2023 Sisi Miao, Communications Engineering Lab @ KIT
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This file accompanies the paper
+ *     S. Miao, A. Schnerring, H. Li and L. Schmalen,
+ *     "Neural belief propagation decoding of quantum LDPC codes using overcomplete check matrices,"
+ *     Proc. IEEE Inform. Theory Workshop (ITW), Saint-Malo, France, Apr. 2023, https://arxiv.org/abs/2212.10245
+ */
 #ifndef BPDECODING_STABILIZIERCODES_H
 #define BPDECODING_STABILIZIERCODES_H
 #include <string>

--- a/stabilizerCodes.h
+++ b/stabilizerCodes.h
@@ -3,28 +3,23 @@
 //
 #ifndef BPDECODING_STABILIZIERCODES_H
 #define BPDECODING_STABILIZIERCODES_H
-#include <vector>
-#include <iostream>
-#include <fstream>
-#include <string>
-#include <cmath>
-#include<random>
-#include <functional>
 #include <assert.h>
-enum class stabilizerCodesType{
-    GeneralizedBicycle = 0,
-    HpergraphProduct = 1,
-    toric = 3
-};
+#include <cmath>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+enum class stabilizerCodesType { GeneralizedBicycle = 0, HpergraphProduct = 1, toric = 3 };
 
 class stabilizerCodes {
-public:
-    stabilizerCodes(unsigned n, unsigned k, unsigned m,stabilizerCodesType codeType, bool trained = false);
+  public:
+    stabilizerCodes(unsigned n, unsigned k, unsigned m, stabilizerCodesType codeType, bool trained = false);
 
     std::vector<bool> decode(unsigned int L, double epsilon);
 
-    std::vector<bool>
-    floodingDecode(unsigned int L, double epsilon, const std::vector<unsigned> error);
+    std::vector<bool> floodingDecode(unsigned int L, double epsilon, const std::vector<unsigned> error);
 
     std::vector<bool> checkSucess(const double *Taux, const double *Tauy, const double *Tauz);
     void loadWeights_cn();
@@ -39,14 +34,11 @@ public:
 
     void addErrorGivenPositions(int pos[], int error[], int size);
 
-    void calSyndrome(); //also check if the error is all 0, if true, not decoding needed
+    void calSyndrome(); // also check if the error is all 0, if true, not decoding needed
 
     double bielief_quantize(double Taux, double Tauy, double Tauz);
 
-
     bool print_msg = false;
-
-
 
     stabilizerCodesType mycodetype;
     unsigned N;
@@ -77,6 +69,5 @@ public:
     std::vector<std::vector<std::vector<double>>> weights_cn;
     std::vector<std::vector<std::vector<double>>> weights_vn;
     std::vector<std::vector<double>> weights_llr;
-
 };
-#endif //BPDECODING_STABILIZIERCODES_H
+#endif // BPDECODING_STABILIZIERCODES_H

--- a/stabilizerCodes.h
+++ b/stabilizerCodes.h
@@ -3,12 +3,6 @@
 //
 #ifndef BPDECODING_STABILIZIERCODES_H
 #define BPDECODING_STABILIZIERCODES_H
-#include <assert.h>
-#include <cmath>
-#include <fstream>
-#include <functional>
-#include <iostream>
-#include <random>
 #include <string>
 #include <vector>
 enum class stabilizerCodesType { GeneralizedBicycle = 0, HypergraphProduct = 1, toric = 3 };
@@ -19,7 +13,7 @@ class stabilizerCodes {
 
     std::vector<bool> decode(unsigned int L, double epsilon);
 
-    std::vector<bool> flooding_decode(unsigned int L, double epsilon, const std::vector<unsigned> error);
+    std::vector<bool> flooding_decode(unsigned int L, double epsilon);
 
     std::vector<bool> check_success(const double *Taux, const double *Tauy, const double *Tauz);
     void load_cn_weights();
@@ -32,12 +26,13 @@ class stabilizerCodes {
 
     void add_error_given_epsilon(double epsilon);
 
-    void add_error_given_positions(int pos[], int error[], int size);
+    // void add_error_given_positions(int pos[], int error[], int size);
 
     void calculate_syndrome(); // also check if the error is all 0, if true, not decoding needed
 
     double quantize_belief(double Taux, double Tauy, double Tauz);
 
+  private:
     bool print_msg = false;
 
     stabilizerCodesType mycodetype;

--- a/stabilizerCodes.h
+++ b/stabilizerCodes.h
@@ -11,7 +11,7 @@
 #include <random>
 #include <string>
 #include <vector>
-enum class stabilizerCodesType { GeneralizedBicycle = 0, HpergraphProduct = 1, toric = 3 };
+enum class stabilizerCodesType { GeneralizedBicycle = 0, HypergraphProduct = 1, toric = 3 };
 
 class stabilizerCodes {
   public:
@@ -19,24 +19,24 @@ class stabilizerCodes {
 
     std::vector<bool> decode(unsigned int L, double epsilon);
 
-    std::vector<bool> floodingDecode(unsigned int L, double epsilon, const std::vector<unsigned> error);
+    std::vector<bool> flooding_decode(unsigned int L, double epsilon, const std::vector<unsigned> error);
 
-    std::vector<bool> checkSucess(const double *Taux, const double *Tauy, const double *Tauz);
-    void loadWeights_cn();
-    void loadWeights_vn();
-    void loadWeights_llr();
-    void readH();
-    void readG();
-    inline unsigned traceInnerProduct(unsigned a, unsigned b);
-    bool checksymplectic();
+    std::vector<bool> check_success(const double *Taux, const double *Tauy, const double *Tauz);
+    void load_cn_weights();
+    void load_vn_weights();
+    void load_llr_weights();
+    void read_H();
+    void read_G();
+    inline unsigned trace_inner_product(unsigned a, unsigned b);
+    bool check_symplectic();
 
-    void addErrorGivenEpsilon(double epsilon);
+    void add_error_given_epsilon(double epsilon);
 
-    void addErrorGivenPositions(int pos[], int error[], int size);
+    void add_error_given_positions(int pos[], int error[], int size);
 
-    void calSyndrome(); // also check if the error is all 0, if true, not decoding needed
+    void calculate_syndrome(); // also check if the error is all 0, if true, not decoding needed
 
-    double bielief_quantize(double Taux, double Tauy, double Tauz);
+    double quantize_belief(double Taux, double Tauy, double Tauz);
 
     bool print_msg = false;
 


### PR DESCRIPTION
Hi, I went ahead and put my comments in the form of code changes:

- CMakeLists: fix filename typo
- README: smaller orthographic fixes
- .gitignore added
- README: correct PCMs path
- Python: Added requirements.txt to list python deps
- clang-format: Automatically format code consistently
- C++: Enable compiler warnings
- C++: fix orthographic mistakes, use consistent method naming
- C++: Fix compiler warning, improve error handling
- C++: Lambda instead of bind
- C++: Minor code beautification
- `simulate_FER`: remove unused include
- C++: Add license notifier
- Notebook: Add license information

What I'd still like to do is:

- add instructions to README
- extract the `read_XX` methods into helper functions
  - use the fact that we can read these externally to cache previously read G, H and weight files
  - Profiling shows that the most time is actually spent reading and parsing these files, not doing validation, and they're always the same :)

What we could discuss:

- instead of freestanding executable, have a module which one can just install & use from Python and Jupyter Notebook

