### PR TITLE
Minor cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25)
 project(NBP_jupyter)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 FIND_PACKAGE(OpenMP)
 if(OPENMP_FOUND)
     message("OPENMP FOUND")

--- a/simulateFER.cpp
+++ b/simulateFER.cpp
@@ -23,20 +23,19 @@ int main() {
     stabilizerCodes code(n, k, m, codeType);
     code.check_symplectic();
 
-    int limit1 = 300;
-    int limit2 = 45000000;
+    int max_frame_errors = 300;
+    int max_decoded_words = 45000000;
     //    double ep_list[] =
     //    {0.14,0.13,0.12,0.11,0.1,0.09,0.08,0.07,0.06,0.05,0.04,0.03,0.02,0.01,0.009,0.008,0.007,0.006,0.005};
     double ep_list[] = {
         0.1, 0.09, 0.08, 0.07, 0.06, 0.05, 0.04, 0.03, 0.02, 0.01,
     };
-    std::cout << "%[[" << n << "," << k << +"]], " << m << " checks, " << decIterNum << " iter ";
+    std::cout << "% [[" << n << "," << k << +"]], " << m << " checks, " << decIterNum << " iter ";
     if (trained)
-        std::cout << "trained" << std::endl;
-    else
-        std::cout << std::endl;
+        std::cout << "trained";
+    std::cout << std::endl;
 
-    std::cout << "%collect " << limit1 << " FE or " << limit2 << " decoding reached" << std::endl;
+    std::cout << "% collect " << max_frame_errors << " FEs or " << max_decoded_words << " decoded words" << std::endl;
 
     //    omp_set_num_threads(1);
     for (double epsilon : ep_list) {
@@ -45,7 +44,7 @@ int main() {
 
 #pragma omp parallel
         {
-            while (failure <= limit1 && total_decoding <= limit2) {
+            while (failure <= max_frame_errors && total_decoding <= max_decoded_words) {
                 stabilizerCodes code(n, k, m, codeType, trained);
                 code.add_error_given_epsilon(epsilon);
                 std::vector<bool> success;
@@ -58,7 +57,7 @@ int main() {
                 }
             }
         }
-        std::cout << "%FE " << failure << ", total dec. " << total_decoding << "\\\\" << std::endl;
+        std::cout << "% FE " << failure << ", total dec. " << total_decoding << "\\\\" << std::endl;
         std::cout << epsilon << " " << (failure / total_decoding) << "\\\\" << std::endl;
     }
     return 0;

--- a/stabilizerCodes.cpp
+++ b/stabilizerCodes.cpp
@@ -266,10 +266,8 @@ double stabilizerCodes::quantize_belief(double Tau, double Tau1, double Tau2) {
     return ret_val;
 }
 
-unsigned stabilizerCodes::trace_inner_product(unsigned int a, unsigned int b) {
-    if (a == 0 || b == 0)
-        return 0;
-    if (a == b)
+inline unsigned stabilizerCodes::trace_inner_product(unsigned int a, unsigned int b) {
+    if (a == 0 || b == 0 || a == b)
         return 0;
     return 1;
 }

--- a/stabilizerCodes.cpp
+++ b/stabilizerCodes.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <iostream>
 #include <random>
+#include <sstream>
 
 stabilizerCodes::stabilizerCodes(unsigned n, unsigned k, unsigned m, stabilizerCodesType codeType, bool trained) {
     mycodetype = codeType;
@@ -124,13 +125,13 @@ void stabilizerCodes::read_H() {
     std::vector<std::vector<unsigned>> VariableValues;
 
     std::string line;
-    std::ifstream myfile;
-    myfile.open(filename);
-    if (myfile.is_open()) {
+    std::ifstream matrix_file;
+    matrix_file.open(filename);
+    if (matrix_file.is_open()) {
         // first line, n k
-        getline(myfile, line, ' ');
+        getline(matrix_file, line, ' ');
         unsigned n = std::stoul(line);
-        getline(myfile, line);
+        getline(matrix_file, line);
         unsigned m = std::stoul(line);
 
         if (n != N) {
@@ -140,40 +141,40 @@ void stabilizerCodes::read_H() {
             throw std::runtime_error("read_H: file-specified M not as expected");
         }
         // second line max dv and dc
-        getline(myfile, line, ' ');
+        getline(matrix_file, line, ' ');
         maxDv = std::stoul(line);
-        getline(myfile, line);
+        getline(matrix_file, line);
         maxDc = std::stoul(line);
 
         // third line, dv degrees
         for (unsigned i = 0; i < n - 1; i++) {
-            getline(myfile, line, ' ');
+            getline(matrix_file, line, ' ');
             dv.push_back(std::stoul(line));
             Nvk.emplace_back();
         }
         Nvk.emplace_back();
-        getline(myfile, line);
+        getline(matrix_file, line);
         dv.push_back(std::stoul(line));
 
         // forth line, dc degrees
         for (unsigned i = 0; i < m - 1; i++) {
-            getline(myfile, line, ' ');
+            getline(matrix_file, line, ' ');
             dc.push_back(std::stoul(line));
             Mck.emplace_back();
         }
         Mck.emplace_back();
-        getline(myfile, line);
+        getline(matrix_file, line);
         dc.push_back(std::stoul(line));
 
         // fifth to n+5-th line, dv neighbors
         for (unsigned i = 0; i < n; i++) {
             Nv.emplace_back(dv[i], 0);
             for (unsigned j = 0; j < dv[i] - 1; j++) {
-                getline(myfile, line, ' ');
+                getline(matrix_file, line, ' ');
                 Nv[i][j] = std::stoul(line) - 1;
                 Mck[Nv[i][j]].push_back(j);
             }
-            getline(myfile, line);
+            getline(matrix_file, line);
             Nv[i][dv[i] - 1] = std::stoul(line) - 1;
             Mck[Nv[i][dv[i] - 1]].push_back(dv[i] - 1);
         }
@@ -182,11 +183,11 @@ void stabilizerCodes::read_H() {
         for (unsigned i = 0; i < m; i++) {
             Mc.emplace_back(dc[i], 0);
             for (unsigned j = 0; j < dc[i] - 1; j++) {
-                getline(myfile, line, ' ');
+                getline(matrix_file, line, ' ');
                 Mc[i][j] = std::stoul(line) - 1;
                 Nvk[Mc[i][j]].push_back(j);
             }
-            getline(myfile, line);
+            getline(matrix_file, line);
             Mc[i][dc[i] - 1] = std::stoul(line) - 1;
             Nvk[Mc[i][dc[i] - 1]].push_back(dc[i] - 1);
         }
@@ -194,23 +195,23 @@ void stabilizerCodes::read_H() {
         for (unsigned i = 0; i < m; i++) {
             checkValues.emplace_back(dc[i], 0);
             for (unsigned j = 0; j < dc[i] - 1; j++) {
-                getline(myfile, line, ' ');
+                getline(matrix_file, line, ' ');
                 checkValues[i][j] = std::stoul(line);
             }
-            getline(myfile, line);
+            getline(matrix_file, line);
             checkValues[i][dc[i] - 1] = std::stoul(line);
         }
         // last lines, value of each column
         for (unsigned i = 0; i < n; i++) {
             VariableValues.emplace_back(dv[i], 0);
             for (unsigned j = 0; j < dv[i] - 1; j++) {
-                getline(myfile, line, ' ');
+                getline(matrix_file, line, ' ');
                 VariableValues[i][j] = std::stoul(line);
             }
-            getline(myfile, line);
+            getline(matrix_file, line);
             VariableValues[i][dv[i] - 1] = std::stoul(line);
         }
-        myfile.close();
+        matrix_file.close();
     } else
         std::cout << "Unable to open file" << std::endl;
     checkVal = checkValues;
@@ -221,20 +222,20 @@ void stabilizerCodes::read_G() {
     std::string filename = "./PCMs/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "/" +
                            codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "_G.txt";
     std::string line;
-    std::ifstream myfile;
-    myfile.open(filename);
-    if (myfile.is_open()) {
+    std::ifstream matrix_file;
+    matrix_file.open(filename);
+    if (matrix_file.is_open()) {
         for (unsigned i = 0; i < G_rows; i++) {
             std::vector<unsigned> row(N, 0);
             for (unsigned j = 0; j < N - 1; j++) {
-                getline(myfile, line, ' ');
+                getline(matrix_file, line, ' ');
                 row[j] = std::stoul(line);
             }
-            getline(myfile, line);
+            getline(matrix_file, line);
             row[N - 1] = std::stoul(line);
             G.push_back(row);
         }
-        myfile.close();
+        matrix_file.close();
     } else
         std::cout << "Unable to open file" << std::endl;
 }
@@ -522,134 +523,139 @@ std::string stabilizerCodes::code_type_string() const {
     throw std::invalid_argument("unimplemented codetype");
 }
 
-void stabilizerCodes::load_cn_weights() {
+std::filesystem::path stabilizerCodes::construct_weights_path(std::string_view filename) const {
     std::string codeTypeString = code_type_string();
-    std::string filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
-                           "_" + std::to_string(M) + "/weight_cn.txt";
+    std::stringstream directory_name_builder;
+    directory_name_builder << codeTypeString << "_" << N << "_" << K << "_" << M;
+    std::filesystem::path path = "training_results";
+    path /= directory_name_builder.str();
+    path /= filename;
+
+    return path;
+}
+
+void stabilizerCodes::load_cn_weights() {
+    auto path = construct_weights_path("weight_cn.txt");
     std::vector<std::vector<std::vector<double>>> weight_cn;
     std::string line;
-    std::ifstream myfile;
-    myfile.open(filename);
+    std::ifstream weights_file;
+    weights_file.open(path.c_str());
     unsigned dec_iter;
-    if (myfile.is_open()) {
-        // first line, number of iterations
-        getline(myfile, line);
-        dec_iter = std::stoul(line);
-        trained_iter = dec_iter;
-        // second line, n m
-        getline(myfile, line, ' ');
-        unsigned n = std::stoul(line);
-        getline(myfile, line);
-        unsigned m = std::stoul(line);
+    if (!weights_file.is_open()) {
+        throw std::runtime_error(std::string("Couldn't open check node weights file ") + path.string());
+    }
+    // first line, number of iterations
+    getline(weights_file, line);
+    dec_iter = std::stoul(line);
+    trained_iter = dec_iter;
+    // second line, n m
+    getline(weights_file, line, ' ');
+    unsigned n = std::stoul(line);
+    getline(weights_file, line);
+    unsigned m = std::stoul(line);
 
-        if (n != N) {
-            throw std::runtime_error("load_cn_weights: file-specified N not as expected");
-        }
-        if (m != M) {
-            throw std::runtime_error("load_cn_weights: file-specified M not as expected");
-        }
-        // rest of the lines, value of each rows of all iterations
-        for (unsigned iter = 0; iter < dec_iter; iter++) {
-            weight_cn.emplace_back();
-        }
-        for (unsigned iter = 0; iter < dec_iter; iter++) {
-            std::vector<std::vector<double>> weight_cn_tmp;
-            for (unsigned i = 0; i < m; i++) {
-                std::vector<double> weight_cn_row(dc[i], 0);
-                for (unsigned j = 0; j < dc[i] - 1; j++) {
-                    getline(myfile, line, ' ');
-                    weight_cn_row[j] = std::stod(line);
-                }
-                getline(myfile, line);
-                weight_cn_row[dc[i] - 1] = std::stod(line);
-                weight_cn_tmp.push_back(weight_cn_row);
+    if (n != N) {
+        throw std::runtime_error("load_cn_weights: file-specified N not as expected");
+    }
+    if (m != M) {
+        throw std::runtime_error("load_cn_weights: file-specified M not as expected");
+    }
+    // rest of the lines, value of each rows of all iterations
+    for (unsigned iter = 0; iter < dec_iter; iter++) {
+        weight_cn.emplace_back();
+    }
+    for (unsigned iter = 0; iter < dec_iter; iter++) {
+        std::vector<std::vector<double>> weight_cn_tmp;
+        for (unsigned i = 0; i < m; i++) {
+            std::vector<double> weight_cn_row(dc[i], 0);
+            for (unsigned j = 0; j < dc[i] - 1; j++) {
+                getline(weights_file, line, ' ');
+                weight_cn_row[j] = std::stod(line);
             }
-            weights_cn.push_back(weight_cn_tmp);
+            getline(weights_file, line);
+            weight_cn_row[dc[i] - 1] = std::stod(line);
+            weight_cn_tmp.push_back(weight_cn_row);
         }
+        weights_cn.push_back(weight_cn_tmp);
+    }
 
-        myfile.close();
-    } else
-        std::cout << "Unable to open file" << std::endl;
+    weights_file.close();
 }
 
 void stabilizerCodes::load_llr_weights() {
-    std::string codeTypeString = code_type_string();
-    std::string filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
-                           "_" + std::to_string(M) + "/weight_llr.txt";
+    auto path = construct_weights_path("weight_llr.txt");
     std::vector<std::vector<double>> weight_llr;
 
     std::string line;
-    std::ifstream myfile;
-    myfile.open(filename);
+    std::ifstream weights_file;
+    weights_file.open(path.c_str());
     unsigned dec_iter;
-    if (myfile.is_open()) {
-        // first line, number of iterations
-        getline(myfile, line);
-        dec_iter = std::stoul(line);
+    if (!weights_file.is_open()) {
+        throw std::runtime_error(std::string("Couldn't open check LLR weights file ") + path.string());
+    }
+    // first line, number of iterations
+    getline(weights_file, line);
+    dec_iter = std::stoul(line);
 
-        // rest of the lines, value of all llr weights
-        for (unsigned iter = 0; iter < dec_iter; iter++) {
-            weight_llr.emplace_back(N, 0);
-            for (unsigned i = 0; i < N - 1; i++) {
-                getline(myfile, line, ' ');
-                weight_llr[iter][i] = std::stod(line);
-            }
-            getline(myfile, line);
-            weight_llr[iter][N - 1] = std::stod(line);
+    // rest of the lines, value of all llr weights
+    for (unsigned iter = 0; iter < dec_iter; iter++) {
+        weight_llr.emplace_back(N, 0);
+        for (unsigned i = 0; i < N - 1; i++) {
+            getline(weights_file, line, ' ');
+            weight_llr[iter][i] = std::stod(line);
         }
+        getline(weights_file, line);
+        weight_llr[iter][N - 1] = std::stod(line);
+    }
 
-        myfile.close();
-    } else
-        std::cout << "Unable to open file" << std::endl;
+    weights_file.close();
 
     weights_llr = weight_llr;
 }
 
 void stabilizerCodes::load_vn_weights() {
-    std::string codeTypeString = code_type_string();
-    std::string filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
-                           "_" + std::to_string(M) + "/weight_vn.txt";
+    auto path = construct_weights_path("weight_vn.txt");
     std::vector<std::vector<std::vector<double>>> weight_cn;
     std::string line;
-    std::ifstream myfile;
-    myfile.open(filename);
+    std::ifstream weights_file;
+    weights_file.open(path.c_str());
     unsigned dec_iter;
-    if (myfile.is_open()) {
-        // first line, number of iterations
-        getline(myfile, line);
-        dec_iter = std::stoul(line);
-        // second line, n m
-        getline(myfile, line, ' ');
-        unsigned n = std::stoul(line);
-        getline(myfile, line);
-        unsigned m = std::stoul(line);
+    if (!weights_file.is_open()) {
+        throw std::runtime_error(std::string("Couldn't open variable node weights file ") + path.string());
+    }
+    // first line, number of iterations
+    getline(weights_file, line);
+    dec_iter = std::stoul(line);
+    // second line, n m
+    getline(weights_file, line, ' ');
+    unsigned n = std::stoul(line);
+    getline(weights_file, line);
+    unsigned m = std::stoul(line);
 
-        if (n != N) {
-            throw std::runtime_error("load_vn_weights: file-specified N not as expected");
-        }
-        if (m != M) {
-            throw std::runtime_error("load_vb_weights: file-specified M not as expected");
-        }
-        // rest of the lines, value of each rows of all iterations
-        for (unsigned iter = 0; iter < dec_iter; iter++) {
-            weight_cn.emplace_back();
-        }
-        for (unsigned iter = 0; iter < dec_iter; iter++) {
-            std::vector<std::vector<double>> weight_cn_tmp;
-            for (unsigned i = 0; i < n; i++) {
-                std::vector<double> weight_cn_row(dv[i], 0);
-                for (unsigned j = 0; j < dv[i] - 1; j++) {
-                    getline(myfile, line, ' ');
-                    weight_cn_row[j] = std::stod(line);
-                }
-                getline(myfile, line);
-                weight_cn_row[dv[i] - 1] = std::stod(line);
-                weight_cn_tmp.push_back(weight_cn_row);
+    if (n != N) {
+        throw std::runtime_error("load_vn_weights: file-specified N not as expected");
+    }
+    if (m != M) {
+        throw std::runtime_error("load_vn_weights: file-specified M not as expected");
+    }
+    // rest of the lines, value of each rows of all iterations
+    for (unsigned iter = 0; iter < dec_iter; iter++) {
+        weight_cn.emplace_back();
+    }
+    for (unsigned iter = 0; iter < dec_iter; iter++) {
+        std::vector<std::vector<double>> weight_cn_tmp;
+        for (unsigned i = 0; i < n; i++) {
+            std::vector<double> weight_cn_row(dv[i], 0);
+            for (unsigned j = 0; j < dv[i] - 1; j++) {
+                getline(weights_file, line, ' ');
+                weight_cn_row[j] = std::stod(line);
             }
-            weights_vn.push_back(weight_cn_tmp);
+            getline(weights_file, line);
+            weight_cn_row[dv[i] - 1] = std::stod(line);
+            weight_cn_tmp.push_back(weight_cn_row);
         }
+        weights_vn.push_back(weight_cn_tmp);
+    }
 
-        myfile.close();
-    } else
-        std::cout << "Unable to open file" << std::endl;
+    weights_file.close();
 }

--- a/stabilizerCodes.cpp
+++ b/stabilizerCodes.cpp
@@ -496,19 +496,15 @@ void stabilizerCodes::calculate_syndrome() {
 std::vector<bool> stabilizerCodes::check_success(const double *Taux, const double *Tauy, const double *Tauz) {
     std::vector<bool> success(2, false);
     error_hat = std::vector<unsigned>(N, 0);
-    errorHatString.clear();
     for (unsigned i = 0; i < N; i++) {
         if (Taux[i] > 0 && Tauy[i] > 0 && Tauz[i] > 0) {
             error_hat[i] = 0;
         } else if (Taux[i] < Tauy[i] && Taux[i] < Tauz[i]) {
             error_hat[i] = 1;
-            errorHatString.emplace_back("X" + std::to_string(i));
         } else if (Tauz[i] < Taux[i] && Tauz[i] < Tauy[i]) {
             error_hat[i] = 2;
-            errorHatString.emplace_back("Z" + std::to_string(i));
         } else {
             error_hat[i] = 3;
-            errorHatString.emplace_back("Y" + std::to_string(i));
         }
     }
     for (unsigned i = 0; i < M; i++) {

--- a/stabilizerCodes.cpp
+++ b/stabilizerCodes.cpp
@@ -114,16 +114,7 @@ void stabilizerCodes::add_error_given_epsilon(double epsilon) {
 // void stabilizerCodes::add_error_given_positions(int *pos, int *error, int size) {}
 
 void stabilizerCodes::read_H() {
-    std::string codeTypeString;
-    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)
-        codeTypeString = "GB";
-    else if (mycodetype == stabilizerCodesType::HypergraphProduct)
-        codeTypeString = "HP";
-    else if (mycodetype == stabilizerCodesType::toric)
-        codeTypeString = "toric";
-    else
-        throw std::invalid_argument("unimplemented codetype");
-
+    std::string codeTypeString = code_type_string();
     std::string filename = "./PCMs/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "/" +
                            codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "_H_" +
                            std::to_string(M) + ".alist";
@@ -226,16 +217,7 @@ void stabilizerCodes::read_H() {
     varVal = VariableValues;
 }
 void stabilizerCodes::read_G() {
-    std::string codeTypeString;
-    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)
-        codeTypeString = "GB";
-    else if (mycodetype == stabilizerCodesType::HypergraphProduct)
-        codeTypeString = "HP";
-    else if (mycodetype == stabilizerCodesType::toric)
-        codeTypeString = "toric";
-    else
-        throw std::invalid_argument("unimplemented codetype");
-
+    std::string codeTypeString = code_type_string();
     std::string filename = "./PCMs/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "/" +
                            codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "_G.txt";
     std::string line;
@@ -528,17 +510,20 @@ std::vector<bool> stabilizerCodes::check_success(const double *Taux, const doubl
     return success;
 }
 
-void stabilizerCodes::load_cn_weights() {
-    std::string codeTypeString;
-    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)
-        codeTypeString = "GB";
-    else if (mycodetype == stabilizerCodesType::HypergraphProduct)
-        codeTypeString = "HP";
-    else if (mycodetype == stabilizerCodesType::toric)
-        codeTypeString = "toric";
-    else
-        throw std::invalid_argument("unimplemented codetype");
+std::string stabilizerCodes::code_type_string() const {
+    switch (mycodetype) {
+    case stabilizerCodesType::GeneralizedBicycle:
+        return "GB";
+    case stabilizerCodesType::HypergraphProduct:
+        return "HP";
+    case stabilizerCodesType::toric:
+        return "toric";
+    }
+    throw std::invalid_argument("unimplemented codetype");
+}
 
+void stabilizerCodes::load_cn_weights() {
+    std::string codeTypeString = code_type_string();
     std::string filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
                            "_" + std::to_string(M) + "/weight_cn.txt";
     std::vector<std::vector<std::vector<double>>> weight_cn;
@@ -588,16 +573,7 @@ void stabilizerCodes::load_cn_weights() {
 }
 
 void stabilizerCodes::load_llr_weights() {
-    std::string codeTypeString;
-    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)
-        codeTypeString = "GB";
-    else if (mycodetype == stabilizerCodesType::HypergraphProduct)
-        codeTypeString = "HP";
-    else if (mycodetype == stabilizerCodesType::toric)
-        codeTypeString = "toric";
-    else
-        throw std::invalid_argument("unimplemented codetype");
-
+    std::string codeTypeString = code_type_string();
     std::string filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
                            "_" + std::to_string(M) + "/weight_llr.txt";
     std::vector<std::vector<double>> weight_llr;
@@ -630,16 +606,7 @@ void stabilizerCodes::load_llr_weights() {
 }
 
 void stabilizerCodes::load_vn_weights() {
-    std::string codeTypeString;
-    if (mycodetype == stabilizerCodesType::GeneralizedBicycle)
-        codeTypeString = "GB";
-    else if (mycodetype == stabilizerCodesType::HypergraphProduct)
-        codeTypeString = "HP";
-    else if (mycodetype == stabilizerCodesType::toric)
-        codeTypeString = "toric";
-    else
-        throw std::invalid_argument("unimplemented codetype");
-
+    std::string codeTypeString = code_type_string();
     std::string filename = "./training_results/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) +
                            "_" + std::to_string(M) + "/weight_vn.txt";
     std::vector<std::vector<std::vector<double>>> weight_cn;

--- a/stabilizerCodes.h
+++ b/stabilizerCodes.h
@@ -10,8 +10,11 @@
  */
 #ifndef BPDECODING_STABILIZIERCODES_H
 #define BPDECODING_STABILIZIERCODES_H
+#include <filesystem>
 #include <string>
+#include <string_view>
 #include <vector>
+
 enum class stabilizerCodesType { GeneralizedBicycle = 0, HypergraphProduct = 1, toric = 3 };
 
 class stabilizerCodes {
@@ -29,9 +32,7 @@ class stabilizerCodes {
     void read_H();
     void read_G();
     static inline bool trace_inner_product(unsigned a, unsigned b);
-    std::string code_type_string() const;
     bool check_symplectic();
-
     void add_error_given_epsilon(double epsilon);
 
     // void add_error_given_positions(int pos[], int error[], int size);
@@ -41,6 +42,9 @@ class stabilizerCodes {
     static double quantize_belief(double Taux, double Tauy, double Tauz);
 
   private:
+    std::string code_type_string() const;
+    std::filesystem::path construct_weights_path(std::string_view filename) const;
+
     bool print_msg = false;
 
     stabilizerCodesType mycodetype;

--- a/stabilizerCodes.h
+++ b/stabilizerCodes.h
@@ -28,7 +28,7 @@ class stabilizerCodes {
     void load_llr_weights();
     void read_H();
     void read_G();
-    inline unsigned trace_inner_product(unsigned a, unsigned b);
+    static inline unsigned trace_inner_product(unsigned a, unsigned b);
     bool check_symplectic();
 
     void add_error_given_epsilon(double epsilon);
@@ -37,7 +37,7 @@ class stabilizerCodes {
 
     void calculate_syndrome(); // also check if the error is all 0, if true, not decoding needed
 
-    double quantize_belief(double Taux, double Tauy, double Tauz);
+    static double quantize_belief(double Taux, double Tauy, double Tauz);
 
   private:
     bool print_msg = false;

--- a/stabilizerCodes.h
+++ b/stabilizerCodes.h
@@ -29,6 +29,7 @@ class stabilizerCodes {
     void read_H();
     void read_G();
     static inline bool trace_inner_product(unsigned a, unsigned b);
+    std::string code_type_string() const;
     bool check_symplectic();
 
     void add_error_given_epsilon(double epsilon);

--- a/stabilizerCodes.h
+++ b/stabilizerCodes.h
@@ -28,7 +28,7 @@ class stabilizerCodes {
     void load_llr_weights();
     void read_H();
     void read_G();
-    static inline unsigned trace_inner_product(unsigned a, unsigned b);
+    static inline bool trace_inner_product(unsigned a, unsigned b);
     bool check_symplectic();
 
     void add_error_given_epsilon(double epsilon);

--- a/stabilizerCodes.h
+++ b/stabilizerCodes.h
@@ -53,7 +53,6 @@ class stabilizerCodes {
     std::vector<unsigned> error_hat;
     std::vector<unsigned> syn;
     std::vector<std::string> errorString;
-    std::vector<std::string> errorHatString;
     unsigned maxDc;
     unsigned maxDv;
     std::vector<unsigned> dv;


### PR DESCRIPTION
- C++: removed unused error^ string
- fixup! C++: removed unused error^ string
- C++: slightly improve variable naming
- C++: static and inline methods where class fields are not accessed
- C++: simplify trace inner product
- C++ trace inner product only relevant mod 2, use boolean
- C++: code type string: reduce code duplication
- C++: file loading code deduplication
