### PR TITLE
Nice To Haves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
-project(NBP_jupyter)
-
+project(NBP_jupyter CXX)
 set(CMAKE_CXX_STANDARD 17)
-FIND_PACKAGE(OpenMP)
-if(OPENMP_FOUND)
-    message("OPENMP FOUND")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-endif()
-include_directories(.)
 
 add_executable(NBP_jupyter
         simulateFER.cpp
@@ -18,8 +9,25 @@ add_executable(NBP_jupyter
         helpers.cpp
         )
 
+find_package(OpenMP)
+if(OPENMP_FOUND)
+    target_link_libraries(NBP_jupyter PUBLIC OpenMP::OpenMP_CXX)
+endif()
+
+
 if(MSVC)
     target_compile_options(NBP_jupyter PRIVATE /W4 /WX)
 else()
-    target_compile_options(NBP_jupyter PRIVATE -Wall -Wextra -Wpedantic -ffast-math)
+    target_compile_options(NBP_jupyter PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-ffast-math" fastmath)
+if(fastmath)
+    target_compile_options(NBP_jupyter PRIVATE -ffast-math)
+endif()
+
+check_cxx_compiler_flag("-funsafe-math-optimizations" veryfastmath)
+if(veryfastmath)
+    target_compile_options(NBP_jupyter PRIVATE -funsafe-math-optimizations)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,8 @@ include_directories(.)
 add_executable(NBP_jupyter
         simulateFER.cpp
         stabilizerCodes.cpp
-        stabilizerCodes.h
         fileReader.cpp
-        fileReader.h)
+        )
 
 if(MSVC)
     target_compile_options(NBP_jupyter PRIVATE /W4 /WX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,5 +21,5 @@ add_executable(NBP_jupyter
 if(MSVC)
     target_compile_options(NBP_jupyter PRIVATE /W4 /WX)
 else()
-    target_compile_options(NBP_jupyter PRIVATE -Wall -Wextra -Wpedantic)
+    target_compile_options(NBP_jupyter PRIVATE -Wall -Wextra -Wpedantic -ffast-math)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(NBP_jupyter
         simulateFER.cpp
         stabilizerCodes.cpp
         fileReader.cpp
+        helpers.cpp
         )
 
 if(MSVC)

--- a/fileReader.cpp
+++ b/fileReader.cpp
@@ -8,8 +8,6 @@
 #include <random>
 #include <sstream>
 
-
-
 fileReader::fileReader(unsigned n, unsigned k, unsigned m, stabilizerCodesType codeType, bool trained) {
     mycodetype = codeType;
     N = n;
@@ -26,7 +24,6 @@ fileReader::fileReader(unsigned n, unsigned k, unsigned m, stabilizerCodesType c
     }
 }
 
-
 void fileReader::read_H() {
     std::string codeTypeString = code_type_string();
     std::string filename = "./PCMs/" + codeTypeString + "_" + std::to_string(N) + "_" + std::to_string(K) + "/" +
@@ -36,7 +33,7 @@ void fileReader::read_H() {
     // Mck same shape and Nv, but its value k means the i-th CN being the k-th neigbor of j-th VN
     std::vector<std::vector<unsigned>> checkValues;
     std::vector<std::vector<unsigned>> VariableValues;
-    
+
     std::string line;
     std::ifstream matrix_file;
     matrix_file.open(filename);
@@ -172,7 +169,7 @@ void fileReader::load_cn_weights() {
     unsigned n = std::stoul(line);
     getline(weights_file, line);
     unsigned m = std::stoul(line);
-    
+
     if (n != N) {
         throw std::runtime_error("load_cn_weights: file-specified N not as expected");
     }
@@ -290,7 +287,6 @@ std::filesystem::path fileReader::construct_weights_path(std::string_view filena
     return path;
 }
 
-
 std::string fileReader::code_type_string() const {
     switch (mycodetype) {
     case stabilizerCodesType::GeneralizedBicycle:
@@ -349,6 +345,4 @@ bool fileReader::check_symplectic() {
     return true;
 }
 
-inline bool fileReader::trace_inner_product(unsigned int a, unsigned int b) {
-    return !(a == 0 || b == 0 || a == b);
-}
+inline bool fileReader::trace_inner_product(unsigned int a, unsigned int b) { return !(a == 0 || b == 0 || a == b); }

--- a/fileReader.h
+++ b/fileReader.h
@@ -11,12 +11,11 @@
 #include <string_view>
 #include <vector>
 enum class stabilizerCodesType { GeneralizedBicycle = 0, HypergraphProduct = 1, toric = 3 };
-class fileReader{
+class fileReader {
   public:
     fileReader(unsigned n, unsigned k, unsigned m, stabilizerCodesType codeType, bool trained = false);
     std::string code_type_string() const;
     std::filesystem::path construct_weights_path(std::string_view filename) const;
-
 
     void load_cn_weights();
     void load_vn_weights();
@@ -51,4 +50,3 @@ class fileReader{
     std::vector<std::vector<std::vector<double>>> weights_vn;
     std::vector<std::vector<double>> weights_llr;
 };
-

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -1,0 +1,128 @@
+
+/*
+ * Copyright 2023 Marcus Müller, Communications Engineering Lab @ KIT
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This file accompanies the paper
+ *     S. Miao, A. Schnerring, H. Li and L. Schmalen,
+ *     "Neural belief propagation decoding of quantum LDPC codes using overcomplete check matrices,"
+ *     Proc. IEEE Inform. Theory Workshop (ITW), Saint-Malo, France, Apr. 2023, https://arxiv.org/abs/2212.10245
+ */
+#include "helpers.h"
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+namespace helpers {
+void print_help(std::string_view progname) {
+    std::cout
+        << "Neural Belief Propagation Using Overcomplete Check Matrices\n"
+           "\n"
+           "Usage:\n"
+        << progname
+        << " [options] [Epsilon] [Epsilon]...\n"
+           "\n"
+           "Positional arguments:\n"
+           "  Epsilon                     optionally specify a list of epsilons at which to verify.\n"
+           "                              If no epsilons are given, use default list of epsilons \n"
+           "\n"
+           "Options:\n"
+           "  -r|--range START STEP STOP  Specify a decreasing range of epsilons to use, e.g.,\n"
+           "                              \"-r 0.1 0.025 0.9\" to get 0.1 0.975 0.95 0.925 0.9\n"
+           "\n"
+           "  -e|--max-frame-errors N     Stop simulating after observing N frame errors\n"
+           "  -w|--max-decoded-words N    Stop simulating after decoding N words\n"
+           "\n\n\n"
+           " This program accompanies the paper\n"
+           "     S. Miao, A. Schnerring, H. Li and L. Schmalen,\n"
+           "     \"Neural belief propagation decoding of quantum LDPC codes using overcomplete check matrices,\"\n"
+           "     Proc. IEEE Inform. Theory Workshop (ITW), Saint-Malo, France, Apr. 2023, "
+           "https://arxiv.org/abs/2212.10245\n";
+}
+parse_result parse_arguments(int argument_count, char *arguments[], const std::vector<double> &default_epsilons,
+                             unsigned maximum_frame_errors, unsigned maximum_decoded_words) {
+    parse_result result;
+    result.maximum_frame_errors = maximum_frame_errors;
+    result.maximum_decoded_words = maximum_decoded_words;
+    result.progname = arguments[0];
+    ++arguments;
+    --argument_count;
+
+    if (!argument_count) { // no arguments passed – use default epsilons
+        result.epsilons = default_epsilons;
+        return result; // return empty list
+    }
+
+    while (argument_count) {
+        auto &argument = *(arguments++);
+        const std::string_view argument_view(argument); // for easier comparison
+
+        if (argument_view == "-h" || argument_view == "--help") {
+            result.print_help = true;
+            return result;
+        }
+        if (argument_view == "-r" || argument_view == "--range") {
+            if (argument_count < 4) { // need three more arguments
+                result.print_help = true;
+                return result;
+            }
+            std::string_view start_(*(arguments++));
+            std::string_view step_(*(arguments++));
+            std::string_view stop_(*(arguments++));
+            argument_count -= 3;
+            try {
+                char **ignoreme = nullptr;
+                auto start = std::strtod(start_.data(), ignoreme);
+                auto step = std::strtod(step_.data(), ignoreme);
+                auto stop = std::strtod(stop_.data(), ignoreme);
+                if (stop <= 0.0f) {
+                    throw std::invalid_argument("Stop value needs to be positive");
+                }
+                if (step <= 0.0f) {
+                    throw std::invalid_argument("step value needs to be positive");
+                }
+                if (start <= stop) {
+                    throw std::invalid_argument("Stop value needs to be smaller than start value");
+                }
+                for (double value = start; value >= stop; value -= step) {
+                    result.epsilons.push_back(value);
+                }
+            } catch (std::invalid_argument &exceptions) {
+                std::cerr << "Could not parse range: " << exceptions.what() << "; skipping range.\n";
+            }
+        } else if (argument_view == "-e" || argument_view == "--max-frame-errors") {
+            argument_count--;
+            std::string_view sv(*(arguments++));
+            result.maximum_frame_errors = std::strtoul(sv.data(), nullptr, 10);
+        } else if (argument_view == "-w" || argument_view == "--max-decoded-words") {
+            argument_count--;
+            std::string_view sv(*(arguments++));
+            result.maximum_decoded_words = std::strtoul(sv.data(), nullptr, 10);
+        } else {
+            // we encountered something that doesn't look like a keyword argument -- proceed to parse numbers
+            arguments--;
+            break;
+        }
+        argument_count--;
+    }
+
+    if (!argument_count && result.epsilons.empty()) { // no arguments passed, and no range found – use default epsilons
+        result.epsilons = default_epsilons;
+        return result;
+    }
+
+    result.epsilons.reserve(result.epsilons.size() + argument_count);
+    for (auto counter = argument_count; counter; --counter) {
+        auto argument = *(arguments++);
+        auto value = std::atof(argument);
+        if (value <= 0.0) { // couldn't parse number, or actually 0.0 (or below) was passed
+            std::cerr << "Ignoring argument '" << argument << "' as unparseable or non-positive.\n";
+            continue; // skip this
+        }
+        result.epsilons.push_back(value);
+    }
+    return result;
+}
+
+}; // namespace helpers

--- a/helpers.h
+++ b/helpers.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Marcus Müller, Communications Engineering Lab @ KIT
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This file accompanies the paper
+ *     S. Miao, A. Schnerring, H. Li and L. Schmalen,
+ *     "Neural belief propagation decoding of quantum LDPC codes using overcomplete check matrices,"
+ *     Proc. IEEE Inform. Theory Workshop (ITW), Saint-Malo, France, Apr. 2023, https://arxiv.org/abs/2212.10245
+ */
+#include <string>
+#include <string_view>
+#include <vector>
+namespace helpers {
+struct parse_result {
+    std::vector<double> epsilons;
+    std::string progname;
+    unsigned maximum_frame_errors = 30;
+    unsigned maximum_decoded_words = 45000000;
+    bool print_help = false;
+};
+void print_help(std::string_view progname);
+parse_result parse_arguments(int argument_count, char *arguments[], const std::vector<double> &default_epsilons,
+                             unsigned maximum_frame_errors = 30, unsigned maximum_decoded_words = 45000000);
+} // namespace helpers

--- a/simulateFER.cpp
+++ b/simulateFER.cpp
@@ -10,10 +10,12 @@
  */
 #include "stabilizerCodes.h"
 
+#include "helpers.h"
+
 #include <iostream>
 #include <omp.h>
 
-int main() {
+int main(int argc, char *argv[]) {
     unsigned n = 46;
     unsigned k = 2;
     unsigned m = 800;
@@ -25,20 +27,30 @@ int main() {
     fileReader matrix_suppiler(n, k, m, codeType, trained);
     matrix_suppiler.check_symplectic();
 
-    int max_frame_errors = 300;
-    int max_decoded_words = 45000000;
+    constexpr int default_max_frame_errors = 300;
+    constexpr int default_max_decoded_words = 45000000;
     //    double ep_list[] =
     //    {0.14,0.13,0.12,0.11,0.1,0.09,0.08,0.07,0.06,0.05,0.04,0.03,0.02,0.01,0.009,0.008,0.007,0.006,0.005};
-    double ep_list[] = {
+    const std::vector<double> default_ep_list{
         0.1, 0.09, 0.08, 0.07, 0.06, 0.05, 0.04, 0.03, 0.02, 0.01,
     };
+
+    const auto arguments =
+        helpers::parse_arguments(argc, argv, default_ep_list, default_max_frame_errors, default_max_decoded_words);
+    if (arguments.print_help) {
+        helpers::print_help(arguments.progname);
+        return 0;
+    }
+    const std::vector<double> &ep_list = std::move(arguments.epsilons);
+    const auto max_frame_errors = arguments.maximum_frame_errors;
+    const auto max_decoded_words = arguments.maximum_decoded_words;
+
     std::cout << "% [[" << n << "," << k << +"]], " << m << " checks, " << decIterNum << " iter ";
     if (trained)
         std::cout << ",trained";
-    std::cout << std::endl;
-
-    std::cout << "% collect " << max_frame_errors << " frame errors or " << max_decoded_words
-              << " decoded error patterns" << std::endl;
+    std::cout << "\n"
+              << "% collect " << max_frame_errors << " frame errors or " << max_decoded_words
+              << " decoded error patterns\n";
 
     //    omp_set_num_threads(1);
     for (double epsilon : ep_list) {

--- a/simulateFER.cpp
+++ b/simulateFER.cpp
@@ -24,8 +24,8 @@ int main(int argc, char *argv[]) {
     bool trained = true;
     double ep0 = 0.1;
     stabilizerCodesType codeType = stabilizerCodesType::GeneralizedBicycle;
-    fileReader matrix_suppiler(n, k, m, codeType, trained);
-    matrix_suppiler.check_symplectic();
+    fileReader matrix_supplier(n, k, m, codeType, trained);
+    matrix_supplier.check_symplectic();
 
     constexpr int default_max_frame_errors = 300;
     constexpr int default_max_decoded_words = 45000000;
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
 #pragma omp parallel
         {
             while (failure <= max_frame_errors && total_decoding <= max_decoded_words) {
-                stabilizerCodes code(n, k, m, codeType, matrix_suppiler, trained);
+                stabilizerCodes code(n, k, m, codeType, matrix_supplier, trained);
                 code.add_error_given_epsilon(epsilon);
                 std::vector<bool> success;
                 success = code.decode(decIterNum, ep0);

--- a/simulateFER.cpp
+++ b/simulateFER.cpp
@@ -37,9 +37,8 @@ int main() {
         std::cout << ",trained";
     std::cout << std::endl;
 
-    std::cout << "% collect " << max_frame_errors << " frame errors or " << max_decoded_words << " decoded error patterns" << std::endl;
-
-
+    std::cout << "% collect " << max_frame_errors << " frame errors or " << max_decoded_words
+              << " decoded error patterns" << std::endl;
 
     //    omp_set_num_threads(1);
     for (double epsilon : ep_list) {
@@ -63,7 +62,6 @@ int main() {
         }
         std::cout << "% FE " << failure << ", total dec. " << total_decoding << "\\\\" << std::endl;
         std::cout << epsilon << " " << (failure / total_decoding) << "\\\\" << std::endl;
-
     }
     return 0;
 }

--- a/stabilizerCodes.cpp
+++ b/stabilizerCodes.cpp
@@ -15,7 +15,7 @@
 #include <random>
 #include <sstream>
 
-stabilizerCodes::stabilizerCodes(unsigned n, unsigned k, unsigned m, stabilizerCodesType codeType, const fileReader fr,
+stabilizerCodes::stabilizerCodes(unsigned n, unsigned k, unsigned m, stabilizerCodesType codeType, const fileReader &fr,
                                  bool trained) {
     mycodetype = codeType;
     N = n;
@@ -104,7 +104,7 @@ std::vector<bool> stabilizerCodes::flooding_decode(unsigned int L, double epsilo
     std::vector<bool> success(2, false);
     double L0 = log(3.0 * (1 - epsilon) / epsilon);
 
-    double lambda0 = log((1 + exp(-L0)) / (exp(-L0) + exp(-L0)));
+    double lambda0 = log((1 + exp(-L0)) / (2 * exp(-L0)));
     //
     // Allocate memory for messages
     double **mc2v, **mv2c;
@@ -158,7 +158,7 @@ std::vector<bool> stabilizerCodes::flooding_decode(unsigned int L, double epsilo
             double sign_prod = (syn[i] == 0 ? 1.0 : -1.0);
             // Sum-Product
             for (unsigned j = 0; j < dc[i]; j++) {
-                if (mv2c[Mc[i][j]][Mck[i][j]] != 0)
+                if (mv2c[Mc[i][j]][Mck[i][j]] != 0.0)
                     phi_msg[j] = -1.0 * log(tanh(fabs(mv2c[Mc[i][j]][Mck[i][j]]) / 2.0));
                 else
                     phi_msg[j] = 60;
@@ -171,7 +171,7 @@ std::vector<bool> stabilizerCodes::flooding_decode(unsigned int L, double epsilo
                 double phi_phi_sum = 60;
                 if (phi_extrinsic_phi_sum != 0)
                     phi_phi_sum = -1.0 * log(tanh(phi_extrinsic_phi_sum / 2.0));
-                mc2v[i][j] = phi_phi_sum * sign_prod / (mv2c[Mc[i][j]][Mck[i][j]] >= 0.0 ? 1.0 : -1.0);
+                mc2v[i][j] = phi_phi_sum * sign_prod * (mv2c[Mc[i][j]][Mck[i][j]] >= 0.0 ? 1.0 : -1.0);
                 if (mTrained && decIter < trained_iter)
                     mc2v[i][j] *= weights_cn[decIter][i][j];
                 // sum_cn_msg += fabs(mc2v[i][j]);

--- a/stabilizerCodes.cpp
+++ b/stabilizerCodes.cpp
@@ -15,8 +15,8 @@
 #include <random>
 #include <sstream>
 
-
-stabilizerCodes::stabilizerCodes(unsigned n, unsigned k, unsigned m, stabilizerCodesType codeType, const fileReader fr, bool trained) {
+stabilizerCodes::stabilizerCodes(unsigned n, unsigned k, unsigned m, stabilizerCodesType codeType, const fileReader fr,
+                                 bool trained) {
     mycodetype = codeType;
     N = n;
     K = k;
@@ -34,13 +34,11 @@ stabilizerCodes::stabilizerCodes(unsigned n, unsigned k, unsigned m, stabilizerC
     Nvk = fr.Nvk;
     Mck = fr.Mck;
     G = fr.G;
-    if (trained){
+    if (trained) {
         weights_cn = fr.weights_cn;
         weights_vn = fr.weights_vn;
         weights_llr = fr.weights_llr;
     }
-
-
 }
 
 std::vector<bool> stabilizerCodes::decode(unsigned int L, double epsilon) {
@@ -51,8 +49,6 @@ std::vector<bool> stabilizerCodes::decode(unsigned int L, double epsilon) {
     error_hat = std::vector<unsigned>(N, 0);
     return flooding_decode(L, epsilon);
 }
-
-
 
 void stabilizerCodes::add_error_given_epsilon(double epsilon) {
     error.clear();
@@ -82,7 +78,6 @@ void stabilizerCodes::add_error_given_epsilon(double epsilon) {
 }
 
 // void stabilizerCodes::add_error_given_positions(int *pos, int *error, int size) {}
-
 
 double stabilizerCodes::quantize_belief(double Tau, double Tau1, double Tau2) {
     double nom = log1p(exp(-1.0 * Tau));
@@ -355,5 +350,3 @@ std::vector<bool> stabilizerCodes::check_success(const double *Taux, const doubl
     success[1] = true;
     return success;
 }
-
-

--- a/stabilizerCodes.h
+++ b/stabilizerCodes.h
@@ -18,7 +18,7 @@
 
 class stabilizerCodes {
   public:
-    stabilizerCodes(unsigned n, unsigned k, unsigned m, stabilizerCodesType codeType, const fileReader fr,
+    stabilizerCodes(unsigned n, unsigned k, unsigned m, stabilizerCodesType codeType, const fileReader &fr,
                     bool trained = false);
 
     std::vector<bool> decode(unsigned int L, double epsilon);

--- a/stabilizerCodes.h
+++ b/stabilizerCodes.h
@@ -10,17 +10,16 @@
  */
 #ifndef BPDECODING_STABILIZIERCODES_H
 #define BPDECODING_STABILIZIERCODES_H
+#include "fileReader.h"
 #include <filesystem>
 #include <string>
 #include <string_view>
 #include <vector>
-#include "fileReader.h"
-
-
 
 class stabilizerCodes {
   public:
-    stabilizerCodes(unsigned n, unsigned k, unsigned m, stabilizerCodesType codeType, const fileReader fr, bool trained = false);
+    stabilizerCodes(unsigned n, unsigned k, unsigned m, stabilizerCodesType codeType, const fileReader fr,
+                    bool trained = false);
 
     std::vector<bool> decode(unsigned int L, double epsilon);
 
@@ -39,8 +38,6 @@ class stabilizerCodes {
     static double quantize_belief(double Taux, double Tauy, double Tauz);
 
   private:
-
-
     bool print_msg = false;
 
     stabilizerCodesType mycodetype;


### PR DESCRIPTION
These aren't big things. One typo fix, the rest is just "for fun and a bit of speed". 

At least, users can now run `NBP_jupyter --help` and get some usage information. There's also the option to manually specify the Ep's you want to run at (if unspecified, use the default list as before).

- C++: automated code formatting
- CMake: Don't compile .h files – they're just there to be included from the .cpp files
- C++: add command line parser
- C++: orthographic typo
- C++: use -ffast-math on compilers that support it
- C++: minor speedups due to const ref, double/double comparisons
